### PR TITLE
Abstract common consensus functions

### DIFF
--- a/chain/consensus/common.go
+++ b/chain/consensus/common.go
@@ -1,0 +1,466 @@
+package consensus
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.opencensus.io/stats"
+	"golang.org/x/xerrors"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	logging "github.com/ipfs/go-log/v2"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	cbg "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/filecoin-project/lotus/api"
+	bstore "github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/state"
+	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/store"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/vm"
+	"github.com/filecoin-project/lotus/lib/async"
+	"github.com/filecoin-project/lotus/lib/sigs"
+	"github.com/filecoin-project/lotus/metrics"
+	blockadt "github.com/filecoin-project/specs-actors/actors/util/adt"
+)
+
+// Common operations shared by all consensus algorithm implementations.
+var log = logging.Logger("consensus-common")
+
+// RunAsyncChecks accepts a list of checks to perform in parallel.
+//
+// Each consensus algorithm may choose to perform a set of different
+// checks when a new blocks is received.
+func RunAsyncChecks(ctx context.Context, await []async.ErrorFuture) error {
+	var merr error
+	for _, fut := range await {
+		if err := fut.AwaitContext(ctx); err != nil {
+			merr = multierror.Append(merr, err)
+		}
+	}
+	if merr != nil {
+		mulErr := merr.(*multierror.Error)
+		mulErr.ErrorFormat = func(es []error) string {
+			if len(es) == 1 {
+				return fmt.Sprintf("1 error occurred:\n\t* %+v\n\n", es[0])
+			}
+
+			points := make([]string, len(es))
+			for i, err := range es {
+				points[i] = fmt.Sprintf("* %+v", err)
+			}
+
+			return fmt.Sprintf(
+				"%d errors occurred:\n\t%s\n\n",
+				len(es), strings.Join(points, "\n\t"))
+		}
+		return mulErr
+	}
+
+	return nil
+}
+
+// CommonBlkChecks performed by all consensus implementations.
+//TODO: Take stateManager and ChainStore in a common object abstracted by all consensus algorithms?
+func CommonBlkChecks(ctx context.Context, sm *stmgr.StateManager, cs *store.ChainStore,
+	b *types.FullBlock, baseTs *types.TipSet) []async.ErrorFuture {
+	h := b.Header
+	msgsCheck := async.Err(func() error {
+		if b.Cid() == build.WhitelistedBlock {
+			return nil
+		}
+
+		if err := checkBlockMessages(ctx, sm, cs, b, baseTs); err != nil {
+			return xerrors.Errorf("block had invalid messages: %w", err)
+		}
+		return nil
+	})
+
+	baseFeeCheck := async.Err(func() error {
+		baseFee, err := cs.ComputeBaseFee(ctx, baseTs)
+		if err != nil {
+			return xerrors.Errorf("computing base fee: %w", err)
+		}
+		if types.BigCmp(baseFee, b.Header.ParentBaseFee) != 0 {
+			return xerrors.Errorf("base fee doesn't match: %s (header) != %s (computed)",
+				b.Header.ParentBaseFee, baseFee)
+		}
+		return nil
+	})
+
+	stateRootCheck := async.Err(func() error {
+		stateroot, precp, err := sm.TipSetState(ctx, baseTs)
+		if err != nil {
+			return xerrors.Errorf("get tipsetstate(%d, %s) failed: %w", h.Height, h.Parents, err)
+		}
+
+		if stateroot != h.ParentStateRoot {
+			msgs, err := cs.MessagesForTipset(ctx, baseTs)
+			if err != nil {
+				log.Error("failed to load messages for tipset during tipset state mismatch error: ", err)
+			} else {
+				log.Warn("Messages for tipset with mismatching state:")
+				for i, m := range msgs {
+					mm := m.VMMessage()
+					log.Warnf("Message[%d]: from=%s to=%s method=%d params=%x", i, mm.From, mm.To, mm.Method, mm.Params)
+				}
+			}
+
+			return xerrors.Errorf("parent state root did not match computed state (%s != %s)", h.ParentStateRoot, stateroot)
+		}
+
+		if precp != h.ParentMessageReceipts {
+			return xerrors.Errorf("parent receipts root did not match computed value (%s != %s)", precp, h.ParentMessageReceipts)
+		}
+		return nil
+	})
+
+	return []async.ErrorFuture{
+		msgsCheck,
+		baseFeeCheck,
+		stateRootCheck,
+	}
+}
+
+// Check the validity of the messages included in a block.
+// TODO: We should extract this somewhere else and make the message pool and miner use the same logic
+func checkBlockMessages(ctx context.Context, sm *stmgr.StateManager, cs *store.ChainStore, b *types.FullBlock, baseTs *types.TipSet) error {
+	{
+		var sigCids []cid.Cid // this is what we get for people not wanting the marshalcbor method on the cid type
+		var pubks [][]byte
+
+		for _, m := range b.BlsMessages {
+			sigCids = append(sigCids, m.Cid())
+
+			pubk, err := sm.GetBlsPublicKey(ctx, m.From, baseTs)
+			if err != nil {
+				return xerrors.Errorf("failed to load bls public to validate block: %w", err)
+			}
+
+			pubks = append(pubks, pubk)
+		}
+
+		if err := VerifyBlsAggregate(ctx, b.Header.BLSAggregate, sigCids, pubks); err != nil {
+			return xerrors.Errorf("bls aggregate signature was invalid: %w", err)
+		}
+	}
+
+	nonces := make(map[address.Address]uint64)
+
+	stateroot, _, err := sm.TipSetState(ctx, baseTs)
+	if err != nil {
+		return xerrors.Errorf("failed to compute tipsettate for %s: %w", baseTs.Key(), err)
+	}
+
+	st, err := state.LoadStateTree(cs.ActorStore(ctx), stateroot)
+	if err != nil {
+		return xerrors.Errorf("failed to load base state tree: %w", err)
+	}
+
+	nv := sm.GetNetworkVersion(ctx, b.Header.Height)
+	pl := vm.PricelistByEpoch(b.Header.Height)
+	var sumGasLimit int64
+	checkMsg := func(msg types.ChainMsg) error {
+		m := msg.VMMessage()
+
+		// Phase 1: syntactic validation, as defined in the spec
+		minGas := pl.OnChainMessage(msg.ChainLength())
+		if err := m.ValidForBlockInclusion(minGas.Total(), nv); err != nil {
+			return xerrors.Errorf("msg %s invalid for block inclusion: %w", m.Cid(), err)
+		}
+
+		// ValidForBlockInclusion checks if any single message does not exceed BlockGasLimit
+		// So below is overflow safe
+		sumGasLimit += m.GasLimit
+		if sumGasLimit > build.BlockGasLimit {
+			return xerrors.Errorf("block gas limit exceeded")
+		}
+
+		// Phase 2: (Partial) semantic validation:
+		// the sender exists and is an account actor, and the nonces make sense
+		var sender address.Address
+		if nv >= network.Version13 {
+			sender, err = st.LookupID(m.From)
+			if err != nil {
+				return xerrors.Errorf("failed to lookup sender %s: %w", m.From, err)
+			}
+		} else {
+			sender = m.From
+		}
+
+		if _, ok := nonces[sender]; !ok {
+			// `GetActor` does not validate that this is an account actor.
+			act, err := st.GetActor(sender)
+			if err != nil {
+				return xerrors.Errorf("failed to get actor: %w", err)
+			}
+
+			if !builtin.IsAccountActor(act.Code) {
+				return xerrors.New("Sender must be an account actor")
+			}
+			nonces[sender] = act.Nonce
+		}
+
+		if nonces[sender] != m.Nonce {
+			return xerrors.Errorf("wrong nonce (exp: %d, got: %d)", nonces[sender], m.Nonce)
+		}
+		nonces[sender]++
+
+		return nil
+	}
+
+	// Validate message arrays in a temporary blockstore.
+	tmpbs := bstore.NewMemory()
+	tmpstore := blockadt.WrapStore(ctx, cbor.NewCborStore(tmpbs))
+
+	bmArr := blockadt.MakeEmptyArray(tmpstore)
+	for i, m := range b.BlsMessages {
+		if err := checkMsg(m); err != nil {
+			return xerrors.Errorf("block had invalid bls message at index %d: %w", i, err)
+		}
+
+		c, err := store.PutMessage(ctx, tmpbs, m)
+		if err != nil {
+			return xerrors.Errorf("failed to store message %s: %w", m.Cid(), err)
+		}
+
+		k := cbg.CborCid(c)
+		if err := bmArr.Set(uint64(i), &k); err != nil {
+			return xerrors.Errorf("failed to put bls message at index %d: %w", i, err)
+		}
+	}
+
+	smArr := blockadt.MakeEmptyArray(tmpstore)
+	for i, m := range b.SecpkMessages {
+		if sm.GetNetworkVersion(ctx, b.Header.Height) >= network.Version14 {
+			if m.Signature.Type != crypto.SigTypeSecp256k1 {
+				return xerrors.Errorf("block had invalid secpk message at index %d: %w", i, err)
+			}
+		}
+
+		if err := checkMsg(m); err != nil {
+			return xerrors.Errorf("block had invalid secpk message at index %d: %w", i, err)
+		}
+
+		// `From` being an account actor is only validated inside the `vm.ResolveToKeyAddr` call
+		// in `StateManager.ResolveToKeyAddress` here (and not in `checkMsg`).
+		kaddr, err := sm.ResolveToKeyAddress(ctx, m.Message.From, baseTs)
+		if err != nil {
+			return xerrors.Errorf("failed to resolve key addr: %w", err)
+		}
+
+		if err := sigs.Verify(&m.Signature, kaddr, m.Message.Cid().Bytes()); err != nil {
+			return xerrors.Errorf("secpk message %s has invalid signature: %w", m.Cid(), err)
+		}
+
+		c, err := store.PutMessage(ctx, tmpbs, m)
+		if err != nil {
+			return xerrors.Errorf("failed to store message %s: %w", m.Cid(), err)
+		}
+		k := cbg.CborCid(c)
+		if err := smArr.Set(uint64(i), &k); err != nil {
+			return xerrors.Errorf("failed to put secpk message at index %d: %w", i, err)
+		}
+	}
+
+	bmroot, err := bmArr.Root()
+	if err != nil {
+		return xerrors.Errorf("failed to root bls msgs: %w", err)
+
+	}
+
+	smroot, err := smArr.Root()
+	if err != nil {
+		return xerrors.Errorf("failed to root secp msgs: %w", err)
+	}
+
+	mrcid, err := tmpstore.Put(ctx, &types.MsgMeta{
+		BlsMessages:   bmroot,
+		SecpkMessages: smroot,
+	})
+	if err != nil {
+		return xerrors.Errorf("failed to put msg meta: %w", err)
+	}
+
+	if b.Header.Messages != mrcid {
+		return fmt.Errorf("messages didnt match message root in header")
+	}
+
+	// Finally, flush.
+	err = vm.Copy(ctx, tmpbs, cs.ChainBlockstore(), mrcid)
+	if err != nil {
+		return xerrors.Errorf("failed to flush:%w", err)
+	}
+
+	return nil
+}
+
+// MsgsFromBlockTemplate extracts the different types of messages from a block
+// template and populates the header for the next block to be proposed.
+func MsgsFromBlockTemplate(ctx context.Context, sm *stmgr.StateManager, next *types.BlockHeader,
+	pts *types.TipSet, bt *api.BlockTemplate) ([]*types.Message, []*types.SignedMessage, error) {
+
+	var blsMessages []*types.Message
+	var secpkMessages []*types.SignedMessage
+
+	var blsMsgCids, secpkMsgCids []cid.Cid
+	var blsSigs []crypto.Signature
+	for _, msg := range bt.Messages {
+		if msg.Signature.Type == crypto.SigTypeBLS {
+			blsSigs = append(blsSigs, msg.Signature)
+			blsMessages = append(blsMessages, &msg.Message)
+
+			c, err := sm.ChainStore().PutMessage(ctx, &msg.Message)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			blsMsgCids = append(blsMsgCids, c)
+		} else if msg.Signature.Type == crypto.SigTypeSecp256k1 {
+			c, err := sm.ChainStore().PutMessage(ctx, msg)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			secpkMsgCids = append(secpkMsgCids, c)
+			secpkMessages = append(secpkMessages, msg)
+
+		} else {
+			return nil, nil, xerrors.Errorf("unknown sig type: %d", msg.Signature.Type)
+		}
+	}
+
+	store := sm.ChainStore().ActorStore(ctx)
+	blsmsgroot, err := ToMessagesArray(store, blsMsgCids)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("building bls amt: %w", err)
+	}
+	secpkmsgroot, err := ToMessagesArray(store, secpkMsgCids)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("building secpk amt: %w", err)
+	}
+
+	mmcid, err := store.Put(store.Context(), &types.MsgMeta{
+		BlsMessages:   blsmsgroot,
+		SecpkMessages: secpkmsgroot,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	next.Messages = mmcid
+
+	aggSig, err := AggregateSignatures(blsSigs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	next.BLSAggregate = aggSig
+	pweight, err := sm.ChainStore().Weight(ctx, pts)
+	if err != nil {
+		return nil, nil, err
+	}
+	next.ParentWeight = pweight
+
+	baseFee, err := sm.ChainStore().ComputeBaseFee(ctx, pts)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("computing base fee: %w", err)
+	}
+	next.ParentBaseFee = baseFee
+
+	return blsMessages, secpkMessages, err
+
+}
+
+// Basic sanity-checks performed when a block is proposed locally.
+func validateLocalBlock(ctx context.Context, msg *pubsub.Message) (pubsub.ValidationResult, string) {
+	stats.Record(ctx, metrics.BlockPublished.M(1))
+
+	if size := msg.Size(); size > 1<<20-1<<15 {
+		log.Errorf("ignoring oversize block (%dB)", size)
+		return pubsub.ValidationIgnore, "oversize_block"
+	}
+
+	blk, what, err := decodeAndCheckBlock(msg)
+	if err != nil {
+		log.Errorf("got invalid local block: %s", err)
+		return pubsub.ValidationIgnore, what
+	}
+
+	msg.ValidatorData = blk
+	stats.Record(ctx, metrics.BlockValidationSuccess.M(1))
+	return pubsub.ValidationAccept, ""
+}
+
+func decodeAndCheckBlock(msg *pubsub.Message) (*types.BlockMsg, string, error) {
+	blk, err := types.DecodeBlockMsg(msg.GetData())
+	if err != nil {
+		return nil, "invalid", xerrors.Errorf("error decoding block: %w", err)
+	}
+
+	if count := len(blk.BlsMessages) + len(blk.SecpkMessages); count > build.BlockMessageLimit {
+		return nil, "too_many_messages", fmt.Errorf("block contains too many messages (%d)", count)
+	}
+
+	// make sure we have a signature
+	if blk.Header.BlockSig == nil {
+		return nil, "missing_signature", fmt.Errorf("block without a signature")
+	}
+
+	return blk, "", nil
+}
+
+func validateMsgMeta(ctx context.Context, msg *types.BlockMsg) error {
+	// TODO there has to be a simpler way to do this without the blockstore dance
+	// block headers use adt0
+	store := blockadt.WrapStore(ctx, cbor.NewCborStore(bstore.NewMemory()))
+	bmArr := blockadt.MakeEmptyArray(store)
+	smArr := blockadt.MakeEmptyArray(store)
+
+	for i, m := range msg.BlsMessages {
+		c := cbg.CborCid(m)
+		if err := bmArr.Set(uint64(i), &c); err != nil {
+			return err
+		}
+	}
+
+	for i, m := range msg.SecpkMessages {
+		c := cbg.CborCid(m)
+		if err := smArr.Set(uint64(i), &c); err != nil {
+			return err
+		}
+	}
+
+	bmroot, err := bmArr.Root()
+	if err != nil {
+		return err
+	}
+
+	smroot, err := smArr.Root()
+	if err != nil {
+		return err
+	}
+
+	mrcid, err := store.Put(store.Context(), &types.MsgMeta{
+		BlsMessages:   bmroot,
+		SecpkMessages: smroot,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if msg.Header.Messages != mrcid {
+		return fmt.Errorf("messages didn't match root cid in header")
+	}
+
+	return nil
+}

--- a/chain/consensus/common.go
+++ b/chain/consensus/common.go
@@ -132,7 +132,6 @@ func CommonBlkChecks(ctx context.Context, sm *stmgr.StateManager, cs *store.Chai
 }
 
 // Check the validity of the messages included in a block.
-// TODO: We should extract this somewhere else and make the message pool and miner use the same logic
 func checkBlockMessages(ctx context.Context, sm *stmgr.StateManager, cs *store.ChainStore, b *types.FullBlock, baseTs *types.TipSet) error {
 	{
 		var sigCids []cid.Cid // this is what we get for people not wanting the marshalcbor method on the cid type

--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -4,18 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"os"
-	"strings"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-cid"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	cbg "github.com/whyrusleeping/cbor-gen"
-	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 	"golang.org/x/xerrors"
 
@@ -23,25 +16,20 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/network"
-	blockadt "github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v7/actors/runtime/proof"
 
-	bstore "github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain"
-	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
 	"github.com/filecoin-project/lotus/chain/beacon"
 	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/rand"
-	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/lib/async"
 	"github.com/filecoin-project/lotus/lib/sigs"
-	"github.com/filecoin-project/lotus/metrics"
 	"github.com/filecoin-project/lotus/storage/sealer/ffiwrapper"
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"
 )
@@ -125,17 +113,6 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 		log.Warn("Got block from the future, but within threshold", h.Timestamp, build.Clock.Now().Unix())
 	}
 
-	msgsCheck := async.Err(func() error {
-		if b.Cid() == build.WhitelistedBlock {
-			return nil
-		}
-
-		if err := filec.checkBlockMessages(ctx, b, baseTs); err != nil {
-			return xerrors.Errorf("block had invalid messages: %w", err)
-		}
-		return nil
-	})
-
 	minerCheck := async.Err(func() error {
 		if err := filec.minerIsValid(ctx, h.Miner, baseTs); err != nil {
 			return xerrors.Errorf("minerIsValid failed: %w", err)
@@ -143,17 +120,6 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 		return nil
 	})
 
-	baseFeeCheck := async.Err(func() error {
-		baseFee, err := filec.store.ComputeBaseFee(ctx, baseTs)
-		if err != nil {
-			return xerrors.Errorf("computing base fee: %w", err)
-		}
-		if types.BigCmp(baseFee, b.Header.ParentBaseFee) != 0 {
-			return xerrors.Errorf("base fee doesn't match: %s (header) != %s (computed)",
-				b.Header.ParentBaseFee, baseFee)
-		}
-		return nil
-	})
 	pweight, err := filec.store.Weight(ctx, baseTs)
 	if err != nil {
 		return xerrors.Errorf("getting parent weight: %w", err)
@@ -163,34 +129,6 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 		return xerrors.Errorf("parrent weight different: %s (header) != %s (computed)",
 			b.Header.ParentWeight, pweight)
 	}
-
-	stateRootCheck := async.Err(func() error {
-		stateroot, precp, err := filec.sm.TipSetState(ctx, baseTs)
-		if err != nil {
-			return xerrors.Errorf("get tipsetstate(%d, %s) failed: %w", h.Height, h.Parents, err)
-		}
-
-		if stateroot != h.ParentStateRoot {
-			msgs, err := filec.store.MessagesForTipset(ctx, baseTs)
-			if err != nil {
-				log.Error("failed to load messages for tipset during tipset state mismatch error: ", err)
-			} else {
-				log.Warn("Messages for tipset with mismatching state:")
-				for i, m := range msgs {
-					mm := m.VMMessage()
-					log.Warnf("Message[%d]: from=%s to=%s method=%d params=%x", i, mm.From, mm.To, mm.Method, mm.Params)
-				}
-			}
-
-			return xerrors.Errorf("parent state root did not match computed state (%s != %s)", h.ParentStateRoot, stateroot)
-		}
-
-		if precp != h.ParentMessageReceipts {
-			return xerrors.Errorf("parent receipts root did not match computed value (%s != %s)", precp, h.ParentMessageReceipts)
-		}
-
-		return nil
-	})
 
 	// Stuff that needs worker address
 	waddr, err := stmgr.GetMinerWorkerRaw(ctx, filec.sm, lbst, h.Miner)
@@ -253,10 +191,11 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 	})
 
 	blockSigCheck := async.Err(func() error {
-		if err := sigs.CheckBlockSignature(ctx, h, waddr); err != nil {
+		if err := filec.VerifyBlockSignature(ctx, h, waddr); err != nil {
 			return xerrors.Errorf("check block signature failed: %w", err)
 		}
 		return nil
+
 	})
 
 	beaconValuesCheck := async.Err(func() error {
@@ -305,44 +244,17 @@ func (filec *FilecoinEC) ValidateBlock(ctx context.Context, b *types.FullBlock) 
 		return nil
 	})
 
-	await := []async.ErrorFuture{
+	commonChecks := consensus.CommonBlkChecks(ctx, filec.sm, filec.store, b, baseTs)
+	await := append([]async.ErrorFuture{
 		minerCheck,
 		tktsCheck,
 		blockSigCheck,
 		beaconValuesCheck,
 		wproofCheck,
 		winnerCheck,
-		msgsCheck,
-		baseFeeCheck,
-		stateRootCheck,
-	}
+	}, commonChecks...)
 
-	var merr error
-	for _, fut := range await {
-		if err := fut.AwaitContext(ctx); err != nil {
-			merr = multierror.Append(merr, err)
-		}
-	}
-	if merr != nil {
-		mulErr := merr.(*multierror.Error)
-		mulErr.ErrorFormat = func(es []error) string {
-			if len(es) == 1 {
-				return fmt.Sprintf("1 error occurred:\n\t* %+v\n\n", es[0])
-			}
-
-			points := make([]string, len(es))
-			for i, err := range es {
-				points[i] = fmt.Sprintf("* %+v", err)
-			}
-
-			return fmt.Sprintf(
-				"%d errors occurred:\n\t%s\n\n",
-				len(es), strings.Join(points, "\n\t"))
-		}
-		return mulErr
-	}
-
-	return nil
+	return consensus.RunAsyncChecks(ctx, await)
 }
 
 func blockSanityChecks(h *types.BlockHeader) error {
@@ -433,178 +345,6 @@ func (filec *FilecoinEC) VerifyWinningPoStProof(ctx context.Context, nv network.
 	return nil
 }
 
-// TODO: We should extract this somewhere else and make the message pool and miner use the same logic
-func (filec *FilecoinEC) checkBlockMessages(ctx context.Context, b *types.FullBlock, baseTs *types.TipSet) error {
-	{
-		var sigCids []cid.Cid // this is what we get for people not wanting the marshalcbor method on the cid type
-		var pubks [][]byte
-
-		for _, m := range b.BlsMessages {
-			sigCids = append(sigCids, m.Cid())
-
-			pubk, err := filec.sm.GetBlsPublicKey(ctx, m.From, baseTs)
-			if err != nil {
-				return xerrors.Errorf("failed to load bls public to validate block: %w", err)
-			}
-
-			pubks = append(pubks, pubk)
-		}
-
-		if err := consensus.VerifyBlsAggregate(ctx, b.Header.BLSAggregate, sigCids, pubks); err != nil {
-			return xerrors.Errorf("bls aggregate signature was invalid: %w", err)
-		}
-	}
-
-	nonces := make(map[address.Address]uint64)
-
-	stateroot, _, err := filec.sm.TipSetState(ctx, baseTs)
-	if err != nil {
-		return xerrors.Errorf("failed to compute tipsettate for %s: %w", baseTs.Key(), err)
-	}
-
-	st, err := state.LoadStateTree(filec.store.ActorStore(ctx), stateroot)
-	if err != nil {
-		return xerrors.Errorf("failed to load base state tree: %w", err)
-	}
-
-	nv := filec.sm.GetNetworkVersion(ctx, b.Header.Height)
-	pl := vm.PricelistByEpoch(b.Header.Height)
-	var sumGasLimit int64
-	checkMsg := func(msg types.ChainMsg) error {
-		m := msg.VMMessage()
-
-		// Phase 1: syntactic validation, as defined in the spec
-		minGas := pl.OnChainMessage(msg.ChainLength())
-		if err := m.ValidForBlockInclusion(minGas.Total(), nv); err != nil {
-			return xerrors.Errorf("msg %s invalid for block inclusion: %w", m.Cid(), err)
-		}
-
-		// ValidForBlockInclusion checks if any single message does not exceed BlockGasLimit
-		// So below is overflow safe
-		sumGasLimit += m.GasLimit
-		if sumGasLimit > build.BlockGasLimit {
-			return xerrors.Errorf("block gas limit exceeded")
-		}
-
-		// Phase 2: (Partial) semantic validation:
-		// the sender exists and is an account actor, and the nonces make sense
-		var sender address.Address
-		if nv >= network.Version13 {
-			sender, err = st.LookupID(m.From)
-			if err != nil {
-				return xerrors.Errorf("failed to lookup sender %s: %w", m.From, err)
-			}
-		} else {
-			sender = m.From
-		}
-
-		if _, ok := nonces[sender]; !ok {
-			// `GetActor` does not validate that this is an account actor.
-			act, err := st.GetActor(sender)
-			if err != nil {
-				return xerrors.Errorf("failed to get actor: %w", err)
-			}
-
-			if !builtin.IsAccountActor(act.Code) {
-				return xerrors.New("Sender must be an account actor")
-			}
-			nonces[sender] = act.Nonce
-		}
-
-		if nonces[sender] != m.Nonce {
-			return xerrors.Errorf("wrong nonce (exp: %d, got: %d)", nonces[sender], m.Nonce)
-		}
-		nonces[sender]++
-
-		return nil
-	}
-
-	// Validate message arrays in a temporary blockstore.
-	tmpbs := bstore.NewMemory()
-	tmpstore := blockadt.WrapStore(ctx, cbor.NewCborStore(tmpbs))
-
-	bmArr := blockadt.MakeEmptyArray(tmpstore)
-	for i, m := range b.BlsMessages {
-		if err := checkMsg(m); err != nil {
-			return xerrors.Errorf("block had invalid bls message at index %d: %w", i, err)
-		}
-
-		c, err := store.PutMessage(ctx, tmpbs, m)
-		if err != nil {
-			return xerrors.Errorf("failed to store message %s: %w", m.Cid(), err)
-		}
-
-		k := cbg.CborCid(c)
-		if err := bmArr.Set(uint64(i), &k); err != nil {
-			return xerrors.Errorf("failed to put bls message at index %d: %w", i, err)
-		}
-	}
-
-	smArr := blockadt.MakeEmptyArray(tmpstore)
-	for i, m := range b.SecpkMessages {
-		if filec.sm.GetNetworkVersion(ctx, b.Header.Height) >= network.Version14 {
-			if m.Signature.Type != crypto.SigTypeSecp256k1 {
-				return xerrors.Errorf("block had invalid secpk message at index %d: %w", i, err)
-			}
-		}
-
-		if err := checkMsg(m); err != nil {
-			return xerrors.Errorf("block had invalid secpk message at index %d: %w", i, err)
-		}
-
-		// `From` being an account actor is only validated inside the `vm.ResolveToKeyAddr` call
-		// in `StateManager.ResolveToKeyAddress` here (and not in `checkMsg`).
-		kaddr, err := filec.sm.ResolveToKeyAddress(ctx, m.Message.From, baseTs)
-		if err != nil {
-			return xerrors.Errorf("failed to resolve key addr: %w", err)
-		}
-
-		if err := sigs.Verify(&m.Signature, kaddr, m.Message.Cid().Bytes()); err != nil {
-			return xerrors.Errorf("secpk message %s has invalid signature: %w", m.Cid(), err)
-		}
-
-		c, err := store.PutMessage(ctx, tmpbs, m)
-		if err != nil {
-			return xerrors.Errorf("failed to store message %s: %w", m.Cid(), err)
-		}
-		k := cbg.CborCid(c)
-		if err := smArr.Set(uint64(i), &k); err != nil {
-			return xerrors.Errorf("failed to put secpk message at index %d: %w", i, err)
-		}
-	}
-
-	bmroot, err := bmArr.Root()
-	if err != nil {
-		return xerrors.Errorf("failed to root bls msgs: %w", err)
-
-	}
-
-	smroot, err := smArr.Root()
-	if err != nil {
-		return xerrors.Errorf("failed to root secp msgs: %w", err)
-	}
-
-	mrcid, err := tmpstore.Put(ctx, &types.MsgMeta{
-		BlsMessages:   bmroot,
-		SecpkMessages: smroot,
-	})
-	if err != nil {
-		return xerrors.Errorf("failed to put msg meta: %w", err)
-	}
-
-	if b.Header.Messages != mrcid {
-		return fmt.Errorf("messages didnt match message root in header")
-	}
-
-	// Finally, flush.
-	err = vm.Copy(ctx, tmpbs, filec.store.ChainBlockstore(), mrcid)
-	if err != nil {
-		return xerrors.Errorf("failed to flush:%w", err)
-	}
-
-	return nil
-}
-
 func (filec *FilecoinEC) IsEpochBeyondCurrMax(epoch abi.ChainEpoch) bool {
 	if filec.genesis == nil {
 		return false
@@ -660,140 +400,7 @@ func VerifyVRF(ctx context.Context, worker address.Address, vrfBase, vrfproof []
 var ErrSoftFailure = errors.New("soft validation failure")
 var ErrInsufficientPower = errors.New("incoming block's miner does not have minimum power")
 
-func (filec *FilecoinEC) ValidateBlockPubsub(ctx context.Context, self bool, msg *pubsub.Message) (pubsub.ValidationResult, string) {
-	if self {
-		return filec.validateLocalBlock(ctx, msg)
-	}
-
-	// track validation time
-	begin := build.Clock.Now()
-	defer func() {
-		log.Debugf("block validation time: %s", build.Clock.Since(begin))
-	}()
-
-	stats.Record(ctx, metrics.BlockReceived.M(1))
-
-	recordFailureFlagPeer := func(what string) {
-		// bv.Validate will flag the peer in that case
-		panic(what)
-	}
-
-	blk, what, err := filec.decodeAndCheckBlock(msg)
-	if err != nil {
-		log.Error("got invalid block over pubsub: ", err)
-		recordFailureFlagPeer(what)
-		return pubsub.ValidationReject, what
-	}
-
-	// validate the block meta: the Message CID in the header must match the included messages
-	err = filec.validateMsgMeta(ctx, blk)
-	if err != nil {
-		log.Warnf("error validating message metadata: %s", err)
-		recordFailureFlagPeer("invalid_block_meta")
-		return pubsub.ValidationReject, "invalid_block_meta"
-	}
-
-	reject, err := filec.validateBlockHeader(ctx, blk.Header)
-	if err != nil {
-		if reject == "" {
-			log.Warn("ignoring block msg: ", err)
-			return pubsub.ValidationIgnore, reject
-		}
-		recordFailureFlagPeer(reject)
-		return pubsub.ValidationReject, reject
-	}
-
-	// all good, accept the block
-	msg.ValidatorData = blk
-	stats.Record(ctx, metrics.BlockValidationSuccess.M(1))
-	return pubsub.ValidationAccept, ""
-}
-
-func (filec *FilecoinEC) validateLocalBlock(ctx context.Context, msg *pubsub.Message) (pubsub.ValidationResult, string) {
-	stats.Record(ctx, metrics.BlockPublished.M(1))
-
-	if size := msg.Size(); size > 1<<20-1<<15 {
-		log.Errorf("ignoring oversize block (%dB)", size)
-		return pubsub.ValidationIgnore, "oversize_block"
-	}
-
-	blk, what, err := filec.decodeAndCheckBlock(msg)
-	if err != nil {
-		log.Errorf("got invalid local block: %s", err)
-		return pubsub.ValidationIgnore, what
-	}
-
-	msg.ValidatorData = blk
-	stats.Record(ctx, metrics.BlockValidationSuccess.M(1))
-	return pubsub.ValidationAccept, ""
-}
-
-func (filec *FilecoinEC) decodeAndCheckBlock(msg *pubsub.Message) (*types.BlockMsg, string, error) {
-	blk, err := types.DecodeBlockMsg(msg.GetData())
-	if err != nil {
-		return nil, "invalid", xerrors.Errorf("error decoding block: %w", err)
-	}
-
-	if count := len(blk.BlsMessages) + len(blk.SecpkMessages); count > build.BlockMessageLimit {
-		return nil, "too_many_messages", fmt.Errorf("block contains too many messages (%d)", count)
-	}
-
-	// make sure we have a signature
-	if blk.Header.BlockSig == nil {
-		return nil, "missing_signature", fmt.Errorf("block without a signature")
-	}
-
-	return blk, "", nil
-}
-
-func (filec *FilecoinEC) validateMsgMeta(ctx context.Context, msg *types.BlockMsg) error {
-	// TODO there has to be a simpler way to do this without the blockstore dance
-	// block headers use adt0
-	store := blockadt.WrapStore(ctx, cbor.NewCborStore(bstore.NewMemory()))
-	bmArr := blockadt.MakeEmptyArray(store)
-	smArr := blockadt.MakeEmptyArray(store)
-
-	for i, m := range msg.BlsMessages {
-		c := cbg.CborCid(m)
-		if err := bmArr.Set(uint64(i), &c); err != nil {
-			return err
-		}
-	}
-
-	for i, m := range msg.SecpkMessages {
-		c := cbg.CborCid(m)
-		if err := smArr.Set(uint64(i), &c); err != nil {
-			return err
-		}
-	}
-
-	bmroot, err := bmArr.Root()
-	if err != nil {
-		return err
-	}
-
-	smroot, err := smArr.Root()
-	if err != nil {
-		return err
-	}
-
-	mrcid, err := store.Put(store.Context(), &types.MsgMeta{
-		BlsMessages:   bmroot,
-		SecpkMessages: smroot,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	if msg.Header.Messages != mrcid {
-		return fmt.Errorf("messages didn't match root cid in header")
-	}
-
-	return nil
-}
-
-func (filec *FilecoinEC) validateBlockHeader(ctx context.Context, b *types.BlockHeader) (rejectReason string, err error) {
+func (filec *FilecoinEC) ValidateBlockHeader(ctx context.Context, b *types.BlockHeader) (rejectReason string, err error) {
 
 	// we want to ensure that it is a block from a known miner; we reject blocks from unknown miners
 	// to prevent spam attacks.
@@ -866,6 +473,29 @@ func (filec *FilecoinEC) isChainNearSynced() bool {
 	timestamp := ts.MinTimestamp()
 	timestampTime := time.Unix(int64(timestamp), 0)
 	return build.Clock.Since(timestampTime) < 6*time.Hour
+}
+
+func (filec *FilecoinEC) VerifyBlockSignature(ctx context.Context, h *types.BlockHeader,
+	addr address.Address) error {
+	return sigs.CheckBlockSignature(ctx, h, addr)
+}
+
+func (filec *FilecoinEC) SignBlock(ctx context.Context, w api.Wallet,
+	addr address.Address, next *types.BlockHeader) error {
+
+	nosigbytes, err := next.SigningBytes()
+	if err != nil {
+		return xerrors.Errorf("failed to get signing bytes for block: %w", err)
+	}
+
+	sig, err := w.WalletSign(ctx, addr, nosigbytes, api.MsgMeta{
+		Type: api.MTBlock,
+	})
+	if err != nil {
+		return xerrors.Errorf("failed to sign new block: %w", err)
+	}
+	next.BlockSig = sig
+	return nil
 }
 
 var _ consensus.Consensus = &FilecoinEC{}

--- a/chain/consensus/filcns/mine.go
+++ b/chain/consensus/filcns/mine.go
@@ -3,10 +3,7 @@ package filcns
 import (
 	"context"
 
-	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
-
-	"github.com/filecoin-project/go-state-types/crypto"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/consensus"
@@ -49,86 +46,15 @@ func (filec *FilecoinEC) CreateBlock(ctx context.Context, w api.Wallet, bt *api.
 		ParentMessageReceipts: recpts,
 	}
 
-	var blsMessages []*types.Message
-	var secpkMessages []*types.SignedMessage
-
-	var blsMsgCids, secpkMsgCids []cid.Cid
-	var blsSigs []crypto.Signature
-	for _, msg := range bt.Messages {
-		if msg.Signature.Type == crypto.SigTypeBLS {
-			blsSigs = append(blsSigs, msg.Signature)
-			blsMessages = append(blsMessages, &msg.Message)
-
-			c, err := filec.sm.ChainStore().PutMessage(ctx, &msg.Message)
-			if err != nil {
-				return nil, err
-			}
-
-			blsMsgCids = append(blsMsgCids, c)
-		} else if msg.Signature.Type == crypto.SigTypeSecp256k1 {
-			c, err := filec.sm.ChainStore().PutMessage(ctx, msg)
-			if err != nil {
-				return nil, err
-			}
-
-			secpkMsgCids = append(secpkMsgCids, c)
-			secpkMessages = append(secpkMessages, msg)
-
-		} else {
-			return nil, xerrors.Errorf("unknown sig type: %d", msg.Signature.Type)
-		}
-	}
-
-	store := filec.sm.ChainStore().ActorStore(ctx)
-	blsmsgroot, err := consensus.ToMessagesArray(store, blsMsgCids)
+	blsMessages, secpkMessages, err := consensus.MsgsFromBlockTemplate(ctx, filec.sm, next, pts, bt)
 	if err != nil {
-		return nil, xerrors.Errorf("building bls amt: %w", err)
-	}
-	secpkmsgroot, err := consensus.ToMessagesArray(store, secpkMsgCids)
-	if err != nil {
-		return nil, xerrors.Errorf("building secpk amt: %w", err)
+		return nil, xerrors.Errorf("failed to process messages from block template: %w", err)
 	}
 
-	mmcid, err := store.Put(store.Context(), &types.MsgMeta{
-		BlsMessages:   blsmsgroot,
-		SecpkMessages: secpkmsgroot,
-	})
-	if err != nil {
-		return nil, err
-	}
-	next.Messages = mmcid
-
-	aggSig, err := consensus.AggregateSignatures(blsSigs)
-	if err != nil {
-		return nil, err
-	}
-
-	next.BLSAggregate = aggSig
-	pweight, err := filec.sm.ChainStore().Weight(ctx, pts)
-	if err != nil {
-		return nil, err
-	}
-	next.ParentWeight = pweight
-
-	baseFee, err := filec.sm.ChainStore().ComputeBaseFee(ctx, pts)
-	if err != nil {
-		return nil, xerrors.Errorf("computing base fee: %w", err)
-	}
-	next.ParentBaseFee = baseFee
-
-	nosigbytes, err := next.SigningBytes()
-	if err != nil {
-		return nil, xerrors.Errorf("failed to get signing bytes for block: %w", err)
-	}
-
-	sig, err := w.WalletSign(ctx, worker, nosigbytes, api.MsgMeta{
-		Type: api.MTBlock,
-	})
+	filec.SignBlock(ctx, w, worker, next)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to sign new block: %w", err)
 	}
-
-	next.BlockSig = sig
 
 	fullBlock := &types.FullBlock{
 		Header:        next,

--- a/chain/consensus/iface.go
+++ b/chain/consensus/iface.go
@@ -18,12 +18,35 @@ import (
 )
 
 type Consensus interface {
-	ValidateBlock(ctx context.Context, b *types.FullBlock) (err error)
+	// ValidateBlockHeader is called by peers when they receive a new block through the network.
+	//
+	// This is a fast sanity-check validation performed by the PubSub protocol before delivering
+	// it to the syncer. It checks that the block has the right format and it performs
+	// other consensus-specific light verifications like ensuring that the block is signed by
+	// a valid miner, or that it includes all the data required for a full verification.
 	ValidateBlockHeader(ctx context.Context, b *types.BlockHeader) (rejectReason string, err error)
+
+	// ValidateBlock is called by the syncer to determine if to accept a block or not.
+	//
+	// It performs all the checks needed by the syncer to accept
+	// the block (signature verifications, VRF checks, message validity, etc.)
+	ValidateBlock(ctx context.Context, b *types.FullBlock) (err error)
+
+	// IsEpochBeyondCurrMax is used to configure the fork rules for longest-chain
+	// consensus protocols.
 	IsEpochBeyondCurrMax(epoch abi.ChainEpoch) bool
 
+	// CreateBlock implements all the logic required to propose and assemble a new Filecoin block.
+	//
+	// This function encapsulate all the consensus-specific actions to propose a new block
+	// such as the ordering of transactions, the inclusion of consensus proofs, the signature
+	// of the block, etc.
 	CreateBlock(ctx context.Context, w api.Wallet, bt *api.BlockTemplate) (*types.FullBlock, error)
+
+	// SignBlock determines how should blocks be signed for them to be considered valid by the consensus
+	// engine.
 	SignBlock(ctx context.Context, w api.Wallet, addr address.Address, next *types.BlockHeader) error
+	// VerifyBlockSignature verifies the signature scheme implemented by the consensus algorithm.
 	VerifyBlockSignature(ctx context.Context, h *types.BlockHeader, addr address.Address) error
 }
 

--- a/chain/consensus/iface.go
+++ b/chain/consensus/iface.go
@@ -6,7 +6,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.opencensus.io/stats"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/api"
@@ -42,12 +41,6 @@ type Consensus interface {
 	// such as the ordering of transactions, the inclusion of consensus proofs, the signature
 	// of the block, etc.
 	CreateBlock(ctx context.Context, w api.Wallet, bt *api.BlockTemplate) (*types.FullBlock, error)
-
-	// SignBlock determines how should blocks be signed for them to be considered valid by the consensus
-	// engine.
-	SignBlock(ctx context.Context, w api.Wallet, addr address.Address, next *types.BlockHeader) error
-	// VerifyBlockSignature verifies the signature scheme implemented by the consensus algorithm.
-	VerifyBlockSignature(ctx context.Context, h *types.BlockHeader, addr address.Address) error
 }
 
 // RewardFunc parametrizes the logic for rewards when a message is executed.

--- a/chain/consensus/iface.go
+++ b/chain/consensus/iface.go
@@ -4,17 +4,74 @@ import (
 	"context"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"go.opencensus.io/stats"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/metrics"
 )
 
 type Consensus interface {
 	ValidateBlock(ctx context.Context, b *types.FullBlock) (err error)
-	ValidateBlockPubsub(ctx context.Context, self bool, msg *pubsub.Message) (pubsub.ValidationResult, string)
+	ValidateBlockHeader(ctx context.Context, b *types.BlockHeader) (rejectReason string, err error)
 	IsEpochBeyondCurrMax(epoch abi.ChainEpoch) bool
 
 	CreateBlock(ctx context.Context, w api.Wallet, bt *api.BlockTemplate) (*types.FullBlock, error)
+	SignBlock(ctx context.Context, w api.Wallet, addr address.Address, next *types.BlockHeader) error
+	VerifyBlockSignature(ctx context.Context, h *types.BlockHeader, addr address.Address) error
+}
+
+// ValidateBlockPubsub implements the common checks performed by all consensus implementations
+// when a block is received through the pubsub channel.
+func ValidateBlockPubsub(ctx context.Context, cns Consensus, self bool, msg *pubsub.Message) (pubsub.ValidationResult, string) {
+	if self {
+		return validateLocalBlock(ctx, msg)
+	}
+
+	// track validation time
+	begin := build.Clock.Now()
+	defer func() {
+		log.Debugf("block validation time: %s", build.Clock.Since(begin))
+	}()
+
+	stats.Record(ctx, metrics.BlockReceived.M(1))
+
+	recordFailureFlagPeer := func(what string) {
+		// bv.Validate will flag the peer in that case
+		panic(what)
+	}
+
+	blk, what, err := decodeAndCheckBlock(msg)
+	if err != nil {
+		log.Error("got invalid block over pubsub: ", err)
+		recordFailureFlagPeer(what)
+		return pubsub.ValidationReject, what
+	}
+
+	// validate the block meta: the Message CID in the header must match the included messages
+	err = validateMsgMeta(ctx, blk)
+	if err != nil {
+		log.Warnf("error validating message metadata: %s", err)
+		recordFailureFlagPeer("invalid_block_meta")
+		return pubsub.ValidationReject, "invalid_block_meta"
+	}
+
+	reject, err := cns.ValidateBlockHeader(ctx, blk.Header)
+	if err != nil {
+		if reject == "" {
+			log.Warn("ignoring block msg: ", err)
+			return pubsub.ValidationIgnore, reject
+		}
+		recordFailureFlagPeer(reject)
+		return pubsub.ValidationReject, reject
+	}
+
+	// all good, accept the block
+	msg.ValidatorData = blk
+	stats.Record(ctx, metrics.BlockValidationSuccess.M(1))
+	return pubsub.ValidationAccept, ""
 }

--- a/chain/consensus/iface.go
+++ b/chain/consensus/iface.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/metrics"
 )
 
@@ -24,6 +26,12 @@ type Consensus interface {
 	SignBlock(ctx context.Context, w api.Wallet, addr address.Address, next *types.BlockHeader) error
 	VerifyBlockSignature(ctx context.Context, h *types.BlockHeader, addr address.Address) error
 }
+
+// RewardFunc parametrizes the logic for rewards when a message is executed.
+//
+// Each consensus implementation can set their own reward function.
+type RewardFunc func(ctx context.Context, vmi vm.Interface, em stmgr.ExecMonitor,
+	epoch abi.ChainEpoch, ts *types.TipSet, params []byte) error
 
 // ValidateBlockPubsub implements the common checks performed by all consensus implementations
 // when a block is received through the pubsub channel.

--- a/chain/gen/gen.go
+++ b/chain/gen/gen.go
@@ -31,6 +31,7 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/beacon"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	genesis2 "github.com/filecoin-project/lotus/chain/gen/genesis"
 	"github.com/filecoin-project/lotus/chain/rand"
@@ -255,7 +256,7 @@ func NewGeneratorWithSectorsAndUpgradeSchedule(numSectors int, us stmgr.UpgradeS
 	//return nil, xerrors.Errorf("creating drand beacon: %w", err)
 	//}
 
-	sm, err := stmgr.NewStateManager(cs, filcns.NewTipSetExecutor(), sys, us, beac)
+	sm, err := stmgr.NewStateManager(cs, consensus.NewTipSetExecutor(filcns.RewardFunc), sys, us, beac)
 	if err != nil {
 		return nil, xerrors.Errorf("initing stmgr: %w", err)
 	}

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -35,7 +35,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/reward"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/system"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/verifreg"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -479,7 +479,7 @@ func VerifyPreSealedData(ctx context.Context, cs *store.ChainStore, sys vm.Sysca
 		Epoch:          0,
 		Rand:           &fakeRand{},
 		Bstore:         cs.StateBlockstore(),
-		Actors:         filcns.NewActorRegistry(),
+		Actors:         consensus.NewActorRegistry(),
 		Syscalls:       mkFakedSigSyscalls(sys),
 		CircSupplyCalc: csc,
 		NetworkVersion: nv,

--- a/chain/gen/genesis/miners.go
+++ b/chain/gen/genesis/miners.go
@@ -42,7 +42,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/reward"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -96,7 +96,7 @@ func SetupStorageMiners(ctx context.Context, cs *store.ChainStore, sys vm.Syscal
 			Epoch:          0,
 			Rand:           &fakeRand{},
 			Bstore:         cs.StateBlockstore(),
-			Actors:         filcns.NewActorRegistry(),
+			Actors:         consensus.NewActorRegistry(),
 			Syscalls:       mkFakedSigSyscalls(sys),
 			CircSupplyCalc: csc,
 			NetworkVersion: nv,

--- a/chain/stmgr/forks_test.go
+++ b/chain/stmgr/forks_test.go
@@ -1,4 +1,4 @@
-//stm: #integration
+// stm: #integration
 package stmgr_test
 
 import (
@@ -28,6 +28,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/aerrors"
 	_init "github.com/filecoin-project/lotus/chain/actors/builtin/init"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/gen"
 	. "github.com/filecoin-project/lotus/chain/stmgr"
@@ -125,7 +126,7 @@ func TestForkHeightTriggers(t *testing.T) {
 	}
 
 	sm, err := NewStateManager(
-		cg.ChainStore(), filcns.NewTipSetExecutor(), cg.StateManager().VMSys(), UpgradeSchedule{{
+		cg.ChainStore(), consensus.NewTipSetExecutor(filcns.RewardFunc), cg.StateManager().VMSys(), UpgradeSchedule{{
 			Network: network.Version1,
 			Height:  testForkHeight,
 			Migration: func(ctx context.Context, sm *StateManager, cache MigrationCache, cb ExecMonitor,
@@ -166,7 +167,7 @@ func TestForkHeightTriggers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inv := filcns.NewActorRegistry()
+	inv := consensus.NewActorRegistry()
 	inv.Register(actors.Version0, nil, testActor{})
 
 	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
@@ -270,7 +271,7 @@ func testForkRefuseCall(t *testing.T, nullsBefore, nullsAfter int) {
 
 	var migrationCount int
 	sm, err := NewStateManager(
-		cg.ChainStore(), filcns.NewTipSetExecutor(), cg.StateManager().VMSys(), UpgradeSchedule{{
+		cg.ChainStore(), consensus.NewTipSetExecutor(filcns.RewardFunc), cg.StateManager().VMSys(), UpgradeSchedule{{
 			Network:   network.Version1,
 			Expensive: true,
 			Height:    testForkHeight,
@@ -283,7 +284,7 @@ func testForkRefuseCall(t *testing.T, nullsBefore, nullsAfter int) {
 		t.Fatal(err)
 	}
 
-	inv := filcns.NewActorRegistry()
+	inv := consensus.NewActorRegistry()
 	inv.Register(actors.Version0, nil, testActor{})
 
 	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {
@@ -407,7 +408,7 @@ func TestForkPreMigration(t *testing.T) {
 	counter := make(chan struct{}, 10)
 
 	sm, err := NewStateManager(
-		cg.ChainStore(), filcns.NewTipSetExecutor(), cg.StateManager().VMSys(), UpgradeSchedule{{
+		cg.ChainStore(), consensus.NewTipSetExecutor(filcns.RewardFunc), cg.StateManager().VMSys(), UpgradeSchedule{{
 			Network: network.Version1,
 			Height:  testForkHeight,
 			Migration: func(ctx context.Context, sm *StateManager, cache MigrationCache, cb ExecMonitor,
@@ -504,7 +505,7 @@ func TestForkPreMigration(t *testing.T) {
 		require.NoError(t, sm.Stop(context.Background()))
 	}()
 
-	inv := filcns.NewActorRegistry()
+	inv := consensus.NewActorRegistry()
 	inv.Register(actors.Version0, nil, testActor{})
 
 	sm.SetVMConstructor(func(ctx context.Context, vmopt *vm.VMOpts) (vm.Interface, error) {

--- a/chain/store/store_test.go
+++ b/chain/store/store_test.go
@@ -1,4 +1,4 @@
-//stm: #unit
+// stm: #unit
 package store_test
 
 import (
@@ -14,6 +14,7 @@ import (
 
 	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/gen"
 	"github.com/filecoin-project/lotus/chain/stmgr"
@@ -166,7 +167,7 @@ func TestChainExportImportFull(t *testing.T) {
 		t.Fatal("imported chain differed from exported chain")
 	}
 
-	sm, err := stmgr.NewStateManager(cs, filcns.NewTipSetExecutor(), nil, filcns.DefaultUpgradeSchedule(), cg.BeaconSchedule())
+	sm, err := stmgr.NewStateManager(cs, consensus.NewTipSetExecutor(filcns.RewardFunc), nil, filcns.DefaultUpgradeSchedule(), cg.BeaconSchedule())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/sub/incoming.go
+++ b/chain/sub/incoming.go
@@ -270,7 +270,7 @@ func (bv *BlockValidator) Validate(ctx context.Context, pid peer.ID, msg *pubsub
 	}()
 
 	var what string
-	res, what = bv.consensus.ValidateBlockPubsub(ctx, pid == bv.self, msg)
+	res, what = consensus.ValidateBlockPubsub(ctx, bv.consensus, pid == bv.self, msg)
 	if res == pubsub.ValidationAccept {
 		// it's a good block! make sure we've only seen it once
 		if count := bv.recvBlocks.add(msg.ValidatorData.(*types.BlockMsg).Cid()); count > 0 {

--- a/chain/types/cbor_gen.go
+++ b/chain/types/cbor_gen.go
@@ -8,14 +8,13 @@ import (
 	"math"
 	"sort"
 
-	cid "github.com/ipfs/go-cid"
-	cbg "github.com/whyrusleeping/cbor-gen"
-	xerrors "golang.org/x/xerrors"
-
 	abi "github.com/filecoin-project/go-state-types/abi"
 	crypto "github.com/filecoin-project/go-state-types/crypto"
 	exitcode "github.com/filecoin-project/go-state-types/exitcode"
 	proof "github.com/filecoin-project/go-state-types/proof"
+	cid "github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	xerrors "golang.org/x/xerrors"
 )
 
 var _ = xerrors.Errorf

--- a/chain/vm/cbor_gen.go
+++ b/chain/vm/cbor_gen.go
@@ -8,11 +8,10 @@ import (
 	"math"
 	"sort"
 
+	types "github.com/filecoin-project/lotus/chain/types"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
-
-	types "github.com/filecoin-project/lotus/chain/types"
 )
 
 var _ = xerrors.Errorf

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -39,7 +39,7 @@ import (
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
@@ -499,7 +499,7 @@ var ChainInspectUsage = &cli.Command{
 				return err
 			}
 
-			mm := filcns.NewActorRegistry().Methods[code][m.Message.Method] // TODO: use remote map
+			mm := consensus.NewActorRegistry().Methods[code][m.Message.Method] // TODO: use remote map
 
 			byMethod[mm.Name] += m.Message.GasLimit
 			byMethodC[mm.Name]++

--- a/cli/multisig.go
+++ b/cli/multisig.go
@@ -28,7 +28,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
@@ -325,7 +325,7 @@ var msigInspectCmd = &cli.Command{
 						fmt.Fprintf(w, "%d\t%s\t%d\t%s\t%s\t%s(%d)\t%s\n", txid, "pending", len(tx.Approved), target, types.FIL(tx.Value), "new account, unknown method", tx.Method, paramStr)
 					}
 				} else {
-					method := filcns.NewActorRegistry().Methods[targAct.Code][tx.Method] // TODO: use remote map
+					method := consensus.NewActorRegistry().Methods[targAct.Code][tx.Method] // TODO: use remote map
 
 					if decParams && tx.Method != 0 {
 						ptyp := reflect.New(method.Params.Elem()).Interface().(cbg.CBORUnmarshaler)

--- a/cli/services.go
+++ b/cli/services.go
@@ -17,7 +17,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/lotus/api"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
@@ -88,7 +88,7 @@ func (s *ServicesImpl) DecodeTypedParamsFromJSON(ctx context.Context, to address
 		return nil, err
 	}
 
-	methodMeta, found := filcns.NewActorRegistry().Methods[act.Code][method] // TODO: use remote map
+	methodMeta, found := consensus.NewActorRegistry().Methods[act.Code][method] // TODO: use remote map
 	if !found {
 		return nil, fmt.Errorf("method %d not found on actor %s", method, act.Code)
 	}

--- a/cli/servicesmock_test.go
+++ b/cli/servicesmock_test.go
@@ -8,14 +8,12 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	go_address "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/go-state-types/abi"
 	big "github.com/filecoin-project/go-state-types/big"
-
 	api "github.com/filecoin-project/lotus/api"
 	types "github.com/filecoin-project/lotus/chain/types"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockServicesAPI is a mock of ServicesAPI interface.

--- a/cli/state.go
+++ b/cli/state.go
@@ -40,7 +40,7 @@ import (
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -1368,7 +1368,7 @@ func codeStr(c cid.Cid) string {
 }
 
 func getMethod(code cid.Cid, method abi.MethodNum) string {
-	return filcns.NewActorRegistry().Methods[code][method].Name // todo: use remote
+	return consensus.NewActorRegistry().Methods[code][method].Name // todo: use remote
 }
 
 func toFil(f types.BigInt) types.FIL {
@@ -1399,7 +1399,7 @@ func sumGas(changes []*types.GasTrace) types.GasTrace {
 }
 
 func JsonParams(code cid.Cid, method abi.MethodNum, params []byte) (string, error) {
-	p, err := stmgr.GetParamType(filcns.NewActorRegistry(), code, method) // todo use api for correct actor registry
+	p, err := stmgr.GetParamType(consensus.NewActorRegistry(), code, method) // todo use api for correct actor registry
 	if err != nil {
 		return "", err
 	}
@@ -1413,7 +1413,7 @@ func JsonParams(code cid.Cid, method abi.MethodNum, params []byte) (string, erro
 }
 
 func jsonReturn(code cid.Cid, method abi.MethodNum, ret []byte) (string, error) {
-	methodMeta, found := filcns.NewActorRegistry().Methods[code][method] // TODO: use remote
+	methodMeta, found := consensus.NewActorRegistry().Methods[code][method] // TODO: use remote
 	if !found {
 		return "", fmt.Errorf("method %d not found on actor %s", method, code)
 	}

--- a/cmd/lotus-bench/import.go
+++ b/cmd/lotus-bench/import.go
@@ -34,6 +34,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/blockstore"
 	badgerbs "github.com/filecoin-project/lotus/blockstore/badger"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -227,7 +228,7 @@ var importBenchCmd = &cli.Command{
 		defer cs.Close() //nolint:errcheck
 
 		// TODO: We need to supply the actual beacon after v14
-		stm, err := stmgr.NewStateManager(cs, filcns.NewTipSetExecutor(), vm.Syscalls(verifier), filcns.DefaultUpgradeSchedule(), nil)
+		stm, err := stmgr.NewStateManager(cs, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(verifier), filcns.DefaultUpgradeSchedule(), nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-shed/balances.go
+++ b/cmd/lotus-shed/balances.go
@@ -32,6 +32,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/reward"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/gen/genesis"
 	"github.com/filecoin-project/lotus/chain/state"
@@ -512,7 +513,7 @@ var chainBalanceStateCmd = &cli.Command{
 		cst := cbor.NewCborStore(bs)
 		store := adt.WrapStore(ctx, cst)
 
-		sm, err := stmgr.NewStateManager(cs, filcns.NewTipSetExecutor(), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
+		sm, err := stmgr.NewStateManager(cs, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
 		if err != nil {
 			return err
 		}
@@ -736,7 +737,7 @@ var chainPledgeCmd = &cli.Command{
 		cst := cbor.NewCborStore(bs)
 		store := adt.WrapStore(ctx, cst)
 
-		sm, err := stmgr.NewStateManager(cs, filcns.NewTipSetExecutor(), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
+		sm, err := stmgr.NewStateManager(cs, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-shed/migrations.go
+++ b/cmd/lotus-shed/migrations.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/filecoin-project/specs-actors/v7/actors/migration/nv15"
 
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -75,7 +76,7 @@ var migrationsCmd = &cli.Command{
 		cs := store.NewChainStore(bs, bs, mds, filcns.Weight, nil)
 		defer cs.Close() //nolint:errcheck
 
-		sm, err := stmgr.NewStateManager(cs, filcns.NewTipSetExecutor(), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
+		sm, err := stmgr.NewStateManager(cs, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/lotus-shed/msg.go
+++ b/cmd/lotus-shed/msg.go
@@ -16,7 +16,7 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/v2/actors/builtin/multisig"
 
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 )
@@ -141,7 +141,7 @@ func printMessage(cctx *cli.Context, msg *types.Message) error {
 		return nil
 	}
 
-	fmt.Println("Method:", filcns.NewActorRegistry().Methods[toact.Code][msg.Method].Name) // todo use remote
+	fmt.Println("Method:", consensus.NewActorRegistry().Methods[toact.Code][msg.Method].Name) // todo use remote
 	p, err := lcli.JsonParams(toact.Code, msg.Method, msg.Params)
 	if err != nil {
 		return err

--- a/cmd/lotus-sim/simulation/blockbuilder/blockbuilder.go
+++ b/cmd/lotus-sim/simulation/blockbuilder/blockbuilder.go
@@ -16,7 +16,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/account"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	lrand "github.com/filecoin-project/lotus/chain/rand"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/stmgr"
@@ -84,7 +84,7 @@ func NewBlockBuilder(ctx context.Context, logger *zap.SugaredLogger, sm *stmgr.S
 		Epoch:          parentTs.Height() + 1,
 		Rand:           r,
 		Bstore:         sm.ChainStore().StateBlockstore(),
-		Actors:         filcns.NewActorRegistry(),
+		Actors:         consensus.NewActorRegistry(),
 		Syscalls:       sm.VMSys(),
 		CircSupplyCalc: sm.GetVMCirculatingSupply,
 		NetworkVersion: sm.GetNetworkVersion(ctx, parentTs.Height()+1),

--- a/cmd/lotus-sim/simulation/node.go
+++ b/cmd/lotus-sim/simulation/node.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -105,7 +106,7 @@ func (nd *Node) LoadSim(ctx context.Context, name string) (*Simulation, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create upgrade schedule for simulation %s: %w", name, err)
 	}
-	sim.StateManager, err = stmgr.NewStateManager(nd.Chainstore, filcns.NewTipSetExecutor(), vm.Syscalls(mock.Verifier), us, nil)
+	sim.StateManager, err = stmgr.NewStateManager(nd.Chainstore, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(mock.Verifier), us, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create state manager for simulation %s: %w", name, err)
 	}
@@ -124,7 +125,7 @@ func (nd *Node) CreateSim(ctx context.Context, name string, head *types.TipSet) 
 	if err != nil {
 		return nil, err
 	}
-	sm, err := stmgr.NewStateManager(nd.Chainstore, filcns.NewTipSetExecutor(), vm.Syscalls(mock.Verifier), filcns.DefaultUpgradeSchedule(), nil)
+	sm, err := stmgr.NewStateManager(nd.Chainstore, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(mock.Verifier), filcns.DefaultUpgradeSchedule(), nil)
 	if err != nil {
 		return nil, xerrors.Errorf("creating state manager: %w", err)
 	}

--- a/cmd/lotus-sim/simulation/simulation.go
+++ b/cmd/lotus-sim/simulation/simulation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-state-types/network"
 	blockadt "github.com/filecoin-project/specs-actors/actors/util/adt"
 
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -200,7 +201,7 @@ func (sim *Simulation) SetUpgradeHeight(nv network.Version, epoch abi.ChainEpoch
 	if err != nil {
 		return err
 	}
-	sm, err := stmgr.NewStateManager(sim.Node.Chainstore, filcns.NewTipSetExecutor(), vm.Syscalls(mock.Verifier), newUpgradeSchedule, nil)
+	sm, err := stmgr.NewStateManager(sim.Node.Chainstore, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(mock.Verifier), newUpgradeSchedule, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/lotus-wallet/interactive.go
+++ b/cmd/lotus-wallet/interactive.go
@@ -23,7 +23,7 @@ import (
 	"github.com/filecoin-project/lotus/api/v0api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/multisig"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
 )
@@ -103,7 +103,7 @@ func (c *InteractiveWallet) WalletSign(ctx context.Context, k address.Address, m
 					return xerrors.Errorf("looking up dest actor: %w", err)
 				}
 
-				fmt.Println("Method:", filcns.NewActorRegistry().Methods[toact.Code][cmsg.Method].Name)
+				fmt.Println("Method:", consensus.NewActorRegistry().Methods[toact.Code][cmsg.Method].Name)
 				p, err := lcli.JsonParams(toact.Code, cmsg.Method, cmsg.Params)
 				if err != nil {
 					return err
@@ -125,7 +125,7 @@ func (c *InteractiveWallet) WalletSign(ctx context.Context, k address.Address, m
 						return xerrors.Errorf("looking up msig dest actor: %w", err)
 					}
 
-					fmt.Println("\tMultiSig Proposal Method:", filcns.NewActorRegistry().Methods[toact.Code][mp.Method].Name) // todo use remote
+					fmt.Println("\tMultiSig Proposal Method:", consensus.NewActorRegistry().Methods[toact.Code][mp.Method].Name) // todo use remote
 					p, err := lcli.JsonParams(toact.Code, mp.Method, mp.Params)
 					if err != nil {
 						return err

--- a/cmd/lotus/daemon.go
+++ b/cmd/lotus/daemon.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/chain/store"
@@ -521,7 +522,7 @@ func ImportChain(ctx context.Context, r repo.Repo, fname string, snapshot bool) 
 	}
 
 	// TODO: We need to supply the actual beacon after v14
-	stm, err := stmgr.NewStateManager(cst, filcns.NewTipSetExecutor(), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
+	stm, err := stmgr.NewStateManager(cst, consensus.NewTipSetExecutor(filcns.RewardFunc), vm.Syscalls(ffiwrapper.ProofVerifier), filcns.DefaultUpgradeSchedule(), nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/tvx/extract_many.go
+++ b/cmd/tvx/extract_many.go
@@ -18,8 +18,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/exitcode"
-
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 )
 
 var extractManyFlags struct {
@@ -159,7 +158,7 @@ func runExtractMany(c *cli.Context) error {
 		}
 
 		// Lookup the method in actor method table.
-		if m, ok := filcns.NewActorRegistry().Methods[codeCid]; !ok {
+		if m, ok := consensus.NewActorRegistry().Methods[codeCid]; !ok {
 			return fmt.Errorf("unrecognized actor: %s", actorcode)
 		} else if methodnum >= len(m) {
 			return fmt.Errorf("unrecognized method number for actor %s: %d", actorcode, methodnum)

--- a/conformance/driver.go
+++ b/conformance/driver.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/consensus"
 	"github.com/filecoin-project/lotus/chain/consensus/filcns"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/stmgr"
@@ -103,7 +104,7 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, params 
 		syscalls = vm.Syscalls(ffiwrapper.ProofVerifier)
 
 		cs      = store.NewChainStore(bs, bs, ds, filcns.Weight, nil)
-		tse     = filcns.NewTipSetExecutor()
+		tse     = consensus.NewTipSetExecutor(filcns.RewardFunc)
 		sm, err = stmgr.NewStateManager(cs, tse, syscalls, filcns.DefaultUpgradeSchedule(), nil)
 	)
 	if err != nil {
@@ -120,7 +121,7 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, params 
 
 	defer cs.Close() //nolint:errcheck
 
-	blocks := make([]filcns.FilecoinBlockMessages, 0, len(tipset.Blocks))
+	blocks := make([]consensus.FilecoinBlockMessages, 0, len(tipset.Blocks))
 	for _, b := range tipset.Blocks {
 		sb := store.BlockMessages{
 			Miner: b.MinerAddr,
@@ -142,7 +143,7 @@ func (d *Driver) ExecuteTipset(bs blockstore.Blockstore, ds ds.Batching, params 
 				sb.BlsMessages = append(sb.BlsMessages, msg)
 			}
 		}
-		blocks = append(blocks, filcns.FilecoinBlockMessages{
+		blocks = append(blocks, consensus.FilecoinBlockMessages{
 			BlockMessages: sb,
 			WinCount:      b.WinCount,
 		})
@@ -245,7 +246,7 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, params ExecuteMessageP
 		return nil, cid.Undef, err
 	}
 
-	invoker := filcns.NewActorRegistry()
+	invoker := consensus.NewActorRegistry()
 
 	// register the chaos actor if required by the vector.
 	if chaosOn, ok := d.selector["chaos_actor"]; ok && chaosOn == "true" {
@@ -276,7 +277,8 @@ func (d *Driver) ExecuteMessage(bs blockstore.Blockstore, params ExecuteMessageP
 // messages that originate from secp256k senders, leaving all
 // others untouched.
 // TODO: generate a signature in the DSL so that it's encoded in
-//  the test vector.
+//
+//	the test vector.
 func toChainMsg(msg *types.Message) (ret types.ChainMsg) {
 	ret = msg
 	if msg.From.Protocol() == address.SECP256K1 {

--- a/lotuspond/front/src/chain/methodgen.go
+++ b/lotuspond/front/src/chain/methodgen.go
@@ -8,7 +8,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
-	"github.com/filecoin-project/lotus/chain/consensus/filcns"
+	"github.com/filecoin-project/lotus/chain/consensus"
 )
 
 func main() {
@@ -44,7 +44,7 @@ func main() {
 
 	out := map[string][]string{}
 
-	for c, methods := range filcns.NewActorRegistry().Methods {
+	for c, methods := range consensus.NewActorRegistry().Methods {
 		name := builtin.ActorNameByCode(c)
 		remaining := len(methods)
 

--- a/node/builder_chain.go
+++ b/node/builder_chain.go
@@ -72,7 +72,7 @@ var ChainNode = Options(
 	// Consensus: Chain storage/access
 	Override(new(chain.Genesis), chain.LoadGenesis),
 	Override(new(store.WeightFunc), filcns.Weight),
-	Override(new(stmgr.Executor), filcns.NewTipSetExecutor()),
+	Override(new(stmgr.Executor), consensus.NewTipSetExecutor(filcns.RewardFunc)),
 	Override(new(consensus.Consensus), filcns.NewFilecoinExpectedConsensus),
 	Override(new(*store.ChainStore), modules.ChainStore),
 	Override(new(*stmgr.StateManager), modules.StateManager),


### PR DESCRIPTION
## Related Issues
#1

## Proposed Changes
This PR extends the consensus interface in order to prepare it for the implementation of other consensus algorithms, and it extracts from `FilecoinEC` common logic that will be shared by all consensus implementations.
- Extracted block checks and validation to common functions.
- Extracted `ValidatedPubSub` as a common function.
- Abstracted block signature and verification, and the validation of blocks and their headers. 
- Extracted `compute_state` as common code for all consensus algorithms.
- Abstracted the application of rewards.

## Integration of the interface
To illustrate how can this interface be integrated for the implementation of alternative consensus algorithm, I will share how I imagine it to work and be implemented for Mir:
- `CreateBlock` runs the block proposal logic for Mir in Lotus. In `CreateBlock` Lotus validators pull unverified messages from the mempool, and send them to Mir for ordering. Once the ordered batch is output by Mir, a new Filecoin block is assembled and broadcast through GossipSub to the network. `CreateBlock` calls `SignBlock` if the block needs to be signed.
- Validators are not subscribed to the block gossipsub topic, as they already receive all the information about new blocks through Mir.
- Other Lotus nodes in the network will receive updates about new blocks being proposed by Mir through the Gossipsub block topic. When a new block is received, GossipSub triggers `ValidateBlockHeader` before delivering the block to the node. If the validation succeeds, the block is passed to the syncer which runs `ValidateBlock` to perform a full block validation to determine if the block is valid and can be executed. As part of these verifications, `VerifyBlockSignature` may be called. 
- Finally, the execution of the block triggers the consensus-specific `RewardFunc` that parametrized how should block rewards be distributed among validators.


