### PR TITLE
Add commands to persist and initialize from checkpoint

### DIFF
--- a/chain/consensus/mir/manager.go
+++ b/chain/consensus/mir/manager.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p-core/host"
-	xerrors "golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/mir"
 	"github.com/filecoin-project/mir/pkg/checkpoint"
 	mircrypto "github.com/filecoin-project/mir/pkg/crypto"
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	InterceptorOutputEnv = "MIR_INTERCEPTOR_OUTPUT"
+	InterceptorOutputEnv  = "MIR_INTERCEPTOR_OUTPUT"
+	CheckpointDBKeyPrefix = "mir/checkpoints/"
 )
 
 var (
@@ -58,13 +59,16 @@ type Manager struct {
 	StateManager  *StateManager
 	interceptor   *eventlog.Recorder
 	ToMir         chan chan []*mirproto.Request
-	segmentLength int // segment length determining the checkpoint period.
 	ds            db.DB
 	stopCh        chan struct{}
 
 	// Reconfiguration related types.
 	InitialValidatorSet  *ValidatorSet
 	reconfigurationNonce uint64
+
+	// Checkpoints
+	segmentLength  int    // segment length determining the checkpoint period.
+	checkpointRepo string // path where checkpoints are (optionally) persisted
 }
 
 func NewManager(ctx context.Context, addr address.Address, h host.Host, api v1api.FullNode, ds db.DB, cfg *Config) (*Manager, error) {
@@ -144,6 +148,7 @@ func NewManager(ctx context.Context, addr address.Address, h host.Host, api v1ap
 		ds:                  ds,
 		InitialValidatorSet: initialValidatorSet,
 		ToMir:               make(chan chan []*mirproto.Request),
+		checkpointRepo:      cfg.CheckpointRepo,
 	}
 
 	m.StateManager, err = NewStateManager(ctx, initialMembership, &m, api)
@@ -165,15 +170,19 @@ func NewManager(ctx context.Context, addr address.Address, h host.Host, api v1ap
 	}
 	params.Iss.SegmentLength = m.segmentLength
 
-	latestCh, err := m.latestCheckpoint(params)
-	if err != nil {
-		return nil, fmt.Errorf("error getting inital snapshot SMR system: %w", err)
+	initCh := cfg.InitialCheckpoint
+	// if no initial checkpoint provided in config
+	if initCh == nil {
+		initCh, err = m.initCheckpoint(params, 0)
+		if err != nil {
+			return nil, fmt.Errorf("error getting inital snapshot SMR system: %w", err)
+		}
 	}
 
 	smrSystem, err := smr.New(
 		t.NodeID(mirID),
 		h,
-		latestCh,
+		initCh,
 		m.CryptoManager,
 		m.StateManager,
 		params,
@@ -254,17 +263,8 @@ func (m *Manager) ID() string {
 	return m.Addr.String()
 }
 
-func (m *Manager) latestCheckpoint(params smr.Params) (*checkpoint.StableCheckpoint, error) {
-	b, err := m.ds.Get(m.StateManager.ctx, LatestCheckpointPbKey)
-	if err != nil {
-		if err == datastore.ErrNotFound {
-			return smr.GenesisCheckpoint([]byte{}, params), nil
-		}
-		return nil, xerrors.Errorf("error getting latest snapshot: %w", err)
-	}
-	ch := &checkpoint.StableCheckpoint{}
-	err = ch.Deserialize(b)
-	return ch, err
+func (m *Manager) initCheckpoint(params smr.Params, height abi.ChainEpoch) (*checkpoint.StableCheckpoint, error) {
+	return GetCheckpointByHeight(m.StateManager.ctx, m.ds, height, &params)
 }
 
 // GetMessages extracts Filecoin messages from a Mir batch.

--- a/chain/consensus/mir/types.go
+++ b/chain/consensus/mir/types.go
@@ -2,17 +2,23 @@ package mir
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/multiformats/go-multihash"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/mir/pkg/checkpoint"
+	"github.com/filecoin-project/mir/pkg/systems/smr"
 	t "github.com/filecoin-project/mir/pkg/types"
 
+	"github.com/filecoin-project/lotus/chain/consensus/mir/db"
 	"github.com/filecoin-project/lotus/chain/types"
 	ltypes "github.com/filecoin-project/lotus/chain/types"
 )
@@ -29,13 +35,27 @@ type Config struct {
 	MembershipCfg    interface{}
 	DatastorePath    string
 	CheckpointPeriod int
+	// InitialCheckpoint from which to start the validator.
+	InitialCheckpoint *checkpoint.StableCheckpoint
+	// CheckpointRepo determines the path where Mir checkpoints
+	// will be (optionally) persisted.
+	CheckpointRepo string
 }
 
-func NewConfig(membership interface{}, dbPath string, checkpointPeriod int) *Config {
+func NewConfig(
+	membership interface{},
+	dbPath string,
+	checkpointPeriod int,
+	initCheck *checkpoint.StableCheckpoint,
+	checkpointRepo string,
+) *Config {
+
 	return &Config{
-		MembershipCfg:    membership,
-		DatastorePath:    dbPath,
-		CheckpointPeriod: checkpointPeriod,
+		MembershipCfg:     membership,
+		DatastorePath:     dbPath,
+		CheckpointPeriod:  checkpointPeriod,
+		InitialCheckpoint: initCheck,
+		CheckpointRepo:    checkpointRepo,
 	}
 }
 
@@ -182,4 +202,64 @@ func UnwrapCheckpointSnapshot(ch *checkpoint.StableCheckpoint) (*Checkpoint, err
 	snap := &Checkpoint{}
 	err := snap.FromBytes(ch.Snapshot.AppData)
 	return snap, err
+}
+
+// Get stable checkpoint by height from datastore.
+func GetCheckpointByHeight(ctx context.Context, ds db.DB,
+	height abi.ChainEpoch, params *smr.Params) (*checkpoint.StableCheckpoint, error) {
+
+	var (
+		b   []byte
+		err error
+	)
+	// if no height provided recover Mir from latest checkpoint
+	if height <= 0 {
+		b, err = ds.Get(ctx, LatestCheckpointPbKey)
+		if err != nil {
+			if err == datastore.ErrNotFound {
+				if params != nil {
+					return smr.GenesisCheckpoint([]byte{}, *params), nil
+				} else {
+					return nil, xerrors.Errorf("no checkpoint for height %d or latest checkpoint found in db", height)
+				}
+			}
+			return nil, xerrors.Errorf("error getting latest checkpoint: %w", err)
+		}
+	} else {
+		b, err = ds.Get(ctx, HeightCheckIndexKey(height))
+		if err != nil {
+			if err == datastore.ErrNotFound {
+				return nil, xerrors.Errorf("no checkpoint peristed in database for height: %d", height)
+			}
+			return nil, xerrors.Errorf("error getting checkpoint for height %d: %w", height, err)
+		}
+	}
+
+	ch := &checkpoint.StableCheckpoint{}
+	err = ch.Deserialize(b)
+	return ch, err
+}
+
+// CheckpointToFile persist Mir stable checkpoint on a file.
+func CheckpointToFile(ch *checkpoint.StableCheckpoint, path string) error {
+	b, err := ch.Serialize()
+	if err != nil {
+		return fmt.Errorf("error serializing checkpoint to persist in file: %s", err)
+	}
+	return serializedCheckToFile(b, path)
+}
+
+func serializedCheckToFile(b []byte, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0770); err != nil {
+		return fmt.Errorf("error creating directory for checkpoint persistence: %s", err)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("error creating file to persist checkpoint: %s", err)
+	}
+	_, err = file.Write(b)
+	if err != nil {
+		return fmt.Errorf("error writing checkpoint in file: %s", err)
+	}
+	return nil
 }

--- a/cmd/mir-validator/README.md
+++ b/cmd/mir-validator/README.md
@@ -1,12 +1,53 @@
 # Mir Validator
 `mir-validator` is an application to manage a Mir validator.
 
+## Running a validator.
 Use `make mir-validator` or `make spacenet` to compile the application. To
 run a validator you need to:
 - First spawn a lotus-daemon.
-- Initialize the configuration of mir-validator in $LOTUS_PATH. 
+- Initialize the configuration of mir-validator in $LOTUS_PATH. Be sure to have your $LOTUS_PATH set to the right directory, or it will use the default repo directory (`~/.lotus`).
 `./mir-validator config init`
 - The information about the validators membership for the network is currently stored
 in `$LOTUS_PATH/mir.validators`. To add new validators to the membership list you can either
 paste the information of the new validator in that file (with the format `<wallet_addr>@<multiaddr_with_/p2p_info>`), or run `./mir-validator config add-validator`.
 - Run the validator process using `./mir-validator run --nosync`
+
+## Persisting Mir checkpoints
+Mir relies on the use of checkpoints to recover validators after a failure, and to allow full-nodes (or as we like to call them, _learners_) to verify the validity of blocks received through the network. Learners are not participating from the block validation process, and checkpoints are the only way for them to verify that the blocks received.
+
+If you want to persist every checkpoint produced by mir in a specific path of your validator, you can set the enviroment variable `$CHECKPOINTS_REPO` to point to the directory where you want to store the checkpoints.
+
+Alternatively, if by any chance you are not persisting these checkpoints in `$CHECKPOINTS_REPO` and you want to access them at some point, checkpoints are also persisted in the validator's database. To import and export a checkpoint from and to your validator's database you can use the following commands: 
+```
+# Import a checkpoint from a file
+./mir-validator checkpoint --file <checkpoint_file>
+
+# Export latst checkpoint to file from database
+./mir-validator checkpoint export --output <output-file>
+
+# Export checkpoint for specific height
+./mir-validator checkpoint export --height <height>
+```
+
+> NOTE: `./mir-validator checkpoint` can't be use when the validator is running. These commands insantiate the validator database to access the checkpoints, so they can only be used when the validator is stopped. They are provided to be used when a validator fails (or is shut down) and checkpoints from the validator need to be recovered. If in the future there is a lot of demand for these commands to be available while the validator is running we'll add this feature (so let us know :) ).
+
+## Restarting a validator
+Validators can be restarted seamlessly by running again `./mir-validator run --nosync`. The validator itself will request the latest checkpoint to other validators and sync its state until it catches up and is able to participate from the consensus again. Alternatively, we may restart a validator from a specific checkpoint by providing the `--init-height` and `--init-checkpoint` flags to initialize the validator from a checkpoint at a specific hegiht, or from a checkpoint file, respectively.
+
+For a validator to be able to recover its state successfully, it needs to have its Lotus daemon running, and its daemon needs to be connected to at least some other Lotus daemon in the network with the latest state (ideally another synced validator). The validator will fail to start if it doesn't find any good peer to sync from.
+
+## Recovering a validator from a crash. 
+Crashing validators can be restarted easily by just restarting them as shown in the previous section. However, there may be situations where: `f+1` validators fail and the network stalls, some state is corrupted and the network needs to be restarted from an older state, or there is an attack and we want to do the DAO bail-out again. In these cases, the network can be recovered from an older state as long as we have a valid Mir checkpoint for the desired height we want to recover from, and the corresponding Lotus state for that checkpoint. Ideally, a copy of the backed up Lotus state should be persisted as a snapshot that can be loaded when starting the daemon. The `lotus chain export` command can be used to export a snapshot from the Lotus state for a specific height.
+
+The following steps should be followed in every validator to recover a network from a crash or start a network from a specific network.
+- Start the Lotus daemon with the corresponding state or snapshot of the Mir checkpoint from which the network wants to be restarted.
+```
+# Start daemon from snapshot
+./lotus dameon --import-snapshot <snapshot car file>
+```
+- Once the lotus daemon has been initialized from the right state, we just need to start the mir-validator from the right checkpoint.
+```
+# Start validator from checkpoint
+./mir-validator run --nosync --init-checkpoint=<checkpoint_file>
+```
+Once all `f+1` are restarted with the same state, you should start seeing how the validators start making progress from the height where they were initialized.

--- a/cmd/mir-validator/checkpoint.go
+++ b/cmd/mir-validator/checkpoint.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	_ "net/http/pprof"
+	"os"
+	"path/filepath"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/urfave/cli/v2"
+	"go.opencensus.io/tag"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/mir/pkg/checkpoint"
+
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/consensus/mir"
+	mirkv "github.com/filecoin-project/lotus/chain/consensus/mir/db/kv"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/metrics"
+)
+
+var checkCmd = &cli.Command{
+	Name:  "checkpoint",
+	Usage: "Manage Mir checkpoints",
+	Subcommands: []*cli.Command{
+		importCheckCmd,
+		exportCheckCmd,
+	},
+}
+
+var importCheckCmd = &cli.Command{
+	Name:  "import",
+	Usage: "Imports checkpoint from file",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "file",
+			Aliases: []string{"f"},
+			Usage:   "optionally specify the account used for the validator",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx, _ := tag.New(lcli.DaemonContext(cctx),
+			tag.Insert(metrics.Version, build.BuildVersion),
+			tag.Insert(metrics.Commit, build.CurrentCommit),
+			tag.Insert(metrics.NodeType, "miner"),
+		)
+
+		repoFlag := cctx.String("repo")
+		fileFlag := cctx.String("file")
+
+		// check if validator has been initialized.
+		if err := initCheck(repoFlag); err != nil {
+			return err
+		}
+
+		// Initialize Mir's DB.
+		dbPath := filepath.Join(repoFlag, LevelDSPath)
+		ds, err := mirkv.NewLevelDB(dbPath, false)
+		if err != nil {
+			return fmt.Errorf("error initializing mir datastore: %s", err)
+		}
+
+		_, err = checkpointFromFile(ctx, ds, fileFlag)
+		log.Infof("Import checkpoint from file %s", fileFlag)
+		return err
+	},
+}
+
+var exportCheckCmd = &cli.Command{
+	Name:  "export",
+	Usage: "Exports checkpoint to file",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "output",
+			Usage: "optionally specify the output for the checkpoint",
+		},
+		&cli.IntFlag{
+			Name:  "height",
+			Usage: "optionally specify the height for the checkpoint to export. If not specified the latest one will be exported",
+			Value: 0,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx, _ := tag.New(lcli.DaemonContext(cctx),
+			tag.Insert(metrics.Version, build.BuildVersion),
+			tag.Insert(metrics.Commit, build.CurrentCommit),
+			tag.Insert(metrics.NodeType, "miner"),
+		)
+
+		repoFlag := cctx.String("repo")
+
+		// check if validator has been initialized.
+		if err := initCheck(repoFlag); err != nil {
+			return err
+		}
+
+		// Initialize Mir's DB.
+		dbPath := filepath.Join(repoFlag, LevelDSPath)
+		ds, err := mirkv.NewLevelDB(dbPath, true)
+		if err != nil {
+			return fmt.Errorf("error initializing mir datastore: %s", err)
+		}
+
+		height := abi.ChainEpoch(cctx.Int("height"))
+		ch, err := mir.GetCheckpointByHeight(ctx, ds, height, nil)
+		if err != nil {
+			return fmt.Errorf("error getting checkpoint by height: %s", err)
+		}
+		path := cctx.String("file")
+		heightStr := height.String()
+		if path == "" {
+			if height == 0 {
+				heightStr = "latest"
+			}
+			path = "./checkpoint-height-" + heightStr + ".chkp"
+		}
+		log.Infof("Exporting checkpoint for height %s to file %s", heightStr, path)
+		return mir.CheckpointToFile(ch, path)
+	},
+}
+
+func checkpointFromFile(ctx context.Context, ds datastore.Datastore, path string) (*checkpoint.StableCheckpoint, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error checkpoint from file: %s", err)
+	}
+	ch := &checkpoint.StableCheckpoint{}
+	err = ch.Deserialize(b)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing checkpoint from file: %s", err)
+	}
+	snapshot := &mir.Checkpoint{}
+	if err := snapshot.FromBytes(ch.Snapshot.AppData); err != nil {
+		return nil, xerrors.Errorf("error getting checkpoint snapshot from mir checkpoint: %s", err)
+	}
+	// always flush the checkpoint in database when importing so we have posterior knowledge of it.
+	if err := ds.Put(ctx, mir.HeightCheckIndexKey(snapshot.Height), b); err != nil {
+		return nil, xerrors.Errorf("error flushing checkpoint for height %d in datastore: %w", snapshot.Height, err)
+	}
+	return ch, nil
+}

--- a/cmd/mir-validator/main.go
+++ b/cmd/mir-validator/main.go
@@ -27,6 +27,7 @@ func main() {
 	local := []*cli.Command{
 		runCmd,
 		cfgCmd,
+		checkCmd,
 	}
 
 	jaeger := tracing.SetupJaegerTracing("lotus")
@@ -94,6 +95,12 @@ func main() {
 				EnvVars: []string{"LOTUS_PATH"},
 				Hidden:  true,
 				Value:   path.Join(homeDir, ".lotus"), // TODO: Consider XDG_DATA_HOME
+			},
+			&cli.StringFlag{
+				Name:    "checkpoints-repo",
+				EnvVars: []string{"CHECKPOINTS_REPO"},
+				Hidden:  true,
+				// Value:   path.Join(homeDir, ".lotus"), // TODO: Consider XDG_DATA_HOME
 			},
 			cliutil.FlagVeryVerbose,
 		},


### PR DESCRIPTION
- Persist all checkpoints by height in Mir database. 
- Add `CHECKPOINTS_REPO` environmental variable to allow validator to (optionally) persist every Mir checkpoint in files inside the path determined by the variable. 
- Added `--init-height` and `--init-checkpoint` flags to `./mir-validator run` to initialize the validator from a specific checkpoint in the database or provided by fail. 
- Command to import and export to and from a file checkpoints. 
- Update `mir-validator` README.