### PR TITLE
Bump up used Mir version

### DIFF
--- a/chain/consensus/mir/manager.go
+++ b/chain/consensus/mir/manager.go
@@ -31,7 +31,7 @@ import (
 	mirlibp2p "github.com/filecoin-project/mir/pkg/net/libp2p"
 	mirproto "github.com/filecoin-project/mir/pkg/pb/requestpb"
 	"github.com/filecoin-project/mir/pkg/simplewal"
-	"github.com/filecoin-project/mir/pkg/systems/smr"
+	"github.com/filecoin-project/mir/pkg/systems/trantor"
 	t "github.com/filecoin-project/mir/pkg/types"
 )
 
@@ -160,7 +160,7 @@ func NewManager(ctx context.Context, validatorID address.Address, h host.Host, a
 		pool.DefaultModuleParams(),
 	)
 
-	params := smr.DefaultParams(initialMembership)
+	params := trantor.DefaultParams(initialMembership)
 	params.Iss.SegmentLength = m.segmentLength
 	params.Mempool.MaxTransactionsInBatch = 1024
 	params.Iss.AdjustSpeed(1 * time.Second)
@@ -175,9 +175,9 @@ func NewManager(ctx context.Context, validatorID address.Address, h host.Host, a
 		}
 	}
 
-	smrSystem, err := smr.New(
+	smrSystem, err := trantor.New(
 		t.NodeID(mirID),
-		h,
+		netTransport,
 		initCh,
 		m.CryptoManager,
 		m.StateManager,
@@ -259,7 +259,7 @@ func (m *Manager) ID() string {
 	return m.ValidatorID.String()
 }
 
-func (m *Manager) initCheckpoint(params smr.Params, height abi.ChainEpoch) (*checkpoint.StableCheckpoint, error) {
+func (m *Manager) initCheckpoint(params trantor.Params, height abi.ChainEpoch) (*checkpoint.StableCheckpoint, error) {
 	return GetCheckpointByHeight(m.StateManager.ctx, m.ds, height, &params)
 }
 

--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -20,12 +20,12 @@ import (
 	ltypes "github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/mir/pkg/checkpoint"
 	"github.com/filecoin-project/mir/pkg/pb/requestpb"
-	"github.com/filecoin-project/mir/pkg/systems/smr"
+	"github.com/filecoin-project/mir/pkg/systems/trantor"
 	t "github.com/filecoin-project/mir/pkg/types"
 	"github.com/filecoin-project/mir/pkg/util/maputil"
 )
 
-var _ smr.AppLogic = &StateManager{}
+var _ trantor.AppLogic = &StateManager{}
 
 type Message []byte
 

--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -199,11 +199,6 @@ func (sm *StateManager) applyConfigMsg(in *requestpb.Request) error {
 }
 
 func (sm *StateManager) NewEpoch(nr t.EpochNr) (map[t.NodeID]t.NodeAddress, error) {
-	// Sanity check.
-	if nr != sm.currentEpoch+1 {
-		return nil, xerrors.Errorf("expected next epoch to be %d, got %d", sm.currentEpoch+1, nr)
-	}
-
 	// The base membership is the last one membership.
 	newMembership := maputil.Copy(sm.memberships[nr+ConfigOffset])
 

--- a/chain/consensus/mir/types.go
+++ b/chain/consensus/mir/types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	ltypes "github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/mir/pkg/checkpoint"
-	"github.com/filecoin-project/mir/pkg/systems/smr"
+	"github.com/filecoin-project/mir/pkg/systems/trantor"
 )
 
 const (
@@ -225,7 +225,7 @@ func UnwrapCheckpointSnapshot(ch *checkpoint.StableCheckpoint) (*Checkpoint, err
 
 // GetCheckpointByHeight stable checkpoint by height from datastore.
 func GetCheckpointByHeight(ctx context.Context, ds db.DB,
-	height abi.ChainEpoch, params *smr.Params) (*checkpoint.StableCheckpoint, error) {
+	height abi.ChainEpoch, params *trantor.Params) (*checkpoint.StableCheckpoint, error) {
 
 	var (
 		b   []byte
@@ -237,7 +237,7 @@ func GetCheckpointByHeight(ctx context.Context, ds db.DB,
 		if err != nil {
 			if err == datastore.ErrNotFound {
 				if params != nil {
-					return smr.GenesisCheckpoint([]byte{}, *params), nil
+					return trantor.GenesisCheckpoint([]byte{}, *params), nil
 				} else {
 					return nil, xerrors.Errorf("no checkpoint for height %d or latest checkpoint found in db", height)
 				}

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0
 	github.com/filecoin-project/index-provider v0.9.1
-	github.com/filecoin-project/mir v0.1.3
+	github.com/filecoin-project/mir v0.1.4-0.20230106103901-fa51f5133c09
 	github.com/filecoin-project/pubsub v1.0.0
 	github.com/filecoin-project/specs-actors v0.9.15
 	github.com/filecoin-project/specs-actors/v2 v2.3.6
@@ -185,6 +185,7 @@ require (
 	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect
 	github.com/cskr/pubsub v1.0.2 // indirect
 	github.com/daaku/go.zipexe v1.0.2 // indirect
+	github.com/dave/jennifer v1.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
@@ -282,6 +283,7 @@ require (
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/miekg/dns v1.1.50 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
@@ -353,5 +355,3 @@ require (
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
 
 replace github.com/filecoin-project/test-vectors => ./extern/test-vectors
-
-replace github.com/filecoin-project/mir => ../mir

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/daaku/go.zipexe v1.0.2 h1:Zg55YLYTr7M9wjKn8SY/WcpuuEi+kR2u4E8RhvpyXmk=
 github.com/daaku/go.zipexe v1.0.2/go.mod h1:5xWogtqlYnfBXkSB1o9xysukNP9GTvaNkqzUZbt3Bw8=
+github.com/dave/jennifer v1.5.1 h1:AI8gaM02nCYRw6/WTH0W+S6UNck9YqPZ05xoIxQtuoE=
+github.com/dave/jennifer v1.5.1/go.mod h1:AxTG893FiZKqxy3FP1kL80VMshSMuz2G+EgvszgGRnk=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -373,6 +375,8 @@ github.com/filecoin-project/go-storedcounter v0.1.0 h1:Mui6wSUBC+cQGHbDUBcO7rfh5
 github.com/filecoin-project/go-storedcounter v0.1.0/go.mod h1:4ceukaXi4vFURIoxYMfKzaRF5Xv/Pinh2oTnoxpv+z8=
 github.com/filecoin-project/index-provider v0.9.1 h1:Jnh9dviIHvQxZ2baNoYu3n8z6F9O62ksnVlyREgPyyM=
 github.com/filecoin-project/index-provider v0.9.1/go.mod h1:NlHxQcy2iMGfUoUGUzrRxntcpiC50QSnvp68u2VTT40=
+github.com/filecoin-project/mir v0.1.4-0.20230106103901-fa51f5133c09 h1:5AELiHN1munzfHUCrE44NXQs8K77VAS6QEMrL6GNR/A=
+github.com/filecoin-project/mir v0.1.4-0.20230106103901-fa51f5133c09/go.mod h1:Kn6F75w4+RzAf5agyxel8+QQxf/3mijQ4spmuv+M9Qw=
 github.com/filecoin-project/pubsub v1.0.0 h1:ZTmT27U07e54qV1mMiQo4HDr0buo8I1LDHBYLXlsNXM=
 github.com/filecoin-project/pubsub v1.0.0/go.mod h1:GkpB33CcUtUNrLPhJgfdy4FDx4OMNR9k+46DHx/Lqrg=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
@@ -1360,6 +1364,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/go-xmlrpc v0.0.3/go.mod h1:mqc2dz7tP5x5BKlCahN/n+hs7OSZKJkS9JsHNBRlrxA=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=


### PR DESCRIPTION
This is not yet the next release of Mir, just an intermediate version for development purposes that is close to what the next release will be. It is expected that this version will soon be updated to a newer Mir release.

Using this version of mir, Lotus DOES NOT RUN yet, as the way of announcing new epochs slightly changed. This should be fixed in another commit.

@adlrocha pls have a look and fix that epoch announcement issue.