### PR TITLE
Moves mir-validator commands into eudico command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /AppDir
 /appimage-builder-cache
 *.AppImage
+/eudico
 /lotus
 /lotus-miner
 /lotus-worker

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,9 @@ interopnet: GOFLAGS+=-tags=interopnet
 interopnet: build-devnets
 
 eudico: $(BUILD_DEPS)
-	rm -f eu
+	rm -f eudico
 	$(GOCC) build $(GOFLAGS) -o eudico ./cmd/eudico
+BINS+=eudico
 
 lotus: $(BUILD_DEPS)
 	rm -f lotus

--- a/cmd/eudico/daemon.go
+++ b/cmd/eudico/daemon.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/filecoin-project/go-paramfetch"
 
+	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/filecoin-project/lotus/eudico-core/fxmodules"
@@ -62,6 +63,7 @@ var daemonStopCmd = &cli.Command{
 
 // DaemonCmd is the `eudico daemon` command
 func daemonCmd(consensusAlgorithm global.ConsensusAlgorithm) *cli.Command {
+	api.RunningNodeType = api.NodeFull
 	return &cli.Command{
 		Name:  "daemon",
 		Usage: "Start a eudico daemon process",

--- a/cmd/eudico/main.go
+++ b/cmd/eudico/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/urfave/cli/v2"
 	"go.opencensus.io/trace"
 
-	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
 	cliutil "github.com/filecoin-project/lotus/cli/util"
@@ -31,8 +30,6 @@ var log = logging.Logger("eudico")
 var AdvanceBlockCmd *cli.Command
 
 func main() {
-	api.RunningNodeType = api.NodeFull
-
 	lotuslog.SetupLogLevels()
 
 	local := eudCmds

--- a/cmd/eudico/mir.go
+++ b/cmd/eudico/mir.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lotus/cmd/eudico/mirvalidator"
 	"github.com/filecoin-project/lotus/eudico-core/global"
 )
 
@@ -11,5 +12,6 @@ var mirCmd = &cli.Command{
 	Usage: "Mir consensus",
 	Subcommands: []*cli.Command{
 		daemonCmd(global.MirConsensus),
+		mirvalidator.ValidatorCmd,
 	},
 }

--- a/cmd/eudico/mirvalidator/cfg.go
+++ b/cmd/eudico/mirvalidator/cfg.go
@@ -1,0 +1,145 @@
+package mirvalidator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lotus/chain/consensus/mir"
+	lcli "github.com/filecoin-project/lotus/cli"
+)
+
+// TODO: Make these config files configurable.
+const (
+	PrivKeyPath       = "mir.key"
+	MaddrPath         = "mir.maddr"
+	MembershipCfgPath = "mir.validators"
+	LevelDSPath       = "mir.db"
+)
+
+var configFiles = []string{PrivKeyPath, MaddrPath, MembershipCfgPath, LevelDSPath}
+
+var cfgCmd = &cli.Command{
+	Name:  "config",
+	Usage: "Interact Mir validator config",
+	Subcommands: []*cli.Command{
+		initCmd,
+		addValidatorCmd,
+		validatorAddrCmd,
+	},
+}
+
+var addValidatorCmd = &cli.Command{
+	Name:  "add-validator",
+	Usage: "Append validator to mir membership configuration",
+	Flags: []cli.Flag{},
+	Action: func(cctx *cli.Context) error {
+		if cctx.Args().Len() != 1 {
+			return fmt.Errorf("expected validator address as input")
+		}
+		// check if repo initialized
+		if err := repoInitialized(context.Background(), cctx); err != nil {
+			return err
+		}
+
+		// check if validator has been initialized.
+		if err := initCheck(cctx.String("repo")); err != nil {
+			return err
+		}
+
+		mp := path.Join(cctx.String("repo"), MembershipCfgPath)
+		val, err := mir.ValidatorFromString(cctx.Args().First())
+		if err != nil {
+			return fmt.Errorf("error parsing validator from string: %s. Use the following format: <wallet id>@<multiaddr>", err)
+		}
+		// persist validator config in the right path.
+		if err := mir.ValidatorsToCfg(mir.NewValidatorSet([]mir.Validator{val}), mp); err != nil {
+			return fmt.Errorf("error exporting membership config: %s", err)
+		}
+
+		log.Infow("Mir validator appended to membership config file")
+		return nil
+	},
+}
+
+var validatorAddrCmd = &cli.Command{
+	Name:  "validator-addr",
+	Usage: "Output the validator address formatted to populate membership config",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "default-key",
+			Value: true,
+			Usage: "use default wallet's key",
+		},
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "optionally specify the account used for the validator",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		// check if repo initialized
+		if err := repoInitialized(context.Background(), cctx); err != nil {
+			return err
+		}
+
+		// check if validator has been initialized.
+		if err := initCheck(cctx.String("repo")); err != nil {
+			return err
+		}
+
+		nodeApi, ncloser, err := lcli.GetFullNodeAPIV1(cctx)
+		if err != nil {
+			return xerrors.Errorf("getting full node api: %w", err)
+		}
+		defer ncloser()
+
+		// validator identity.
+		validator, err := validatorIDFromFlag(context.Background(), cctx, nodeApi)
+		if err != nil {
+			return err
+		}
+
+		pk, err := lp2pID(cctx.String("repo"))
+		if err != nil {
+			return fmt.Errorf("error getting libp2p private key: %s", err)
+		}
+		pid, err := peer.IDFromPublicKey(pk.GetPublic())
+		if err != nil {
+			return fmt.Errorf("error generating ID from private key: %s", err)
+		}
+
+		// get multiaddr for host.
+		path := filepath.Join(cctx.String("repo"), MaddrPath)
+		bMaddr, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("error reading multiaddr from file: %w", err)
+		}
+		addrs, err := unmarshalMultiAddrSlice(bMaddr)
+		if err != nil {
+			return err
+		}
+
+		for _, a := range addrs {
+			fmt.Printf("%s@%s/p2p/%s\n", validator, a, pid)
+		}
+
+		return nil
+	},
+}
+
+func cleanConfig(repo string) {
+	log.Infow("Cleaning mir config files from repo")
+	for _, s := range configFiles {
+		p := filepath.Join(repo, s)
+		err := os.Remove(p)
+		if err != nil {
+			log.Warnf("error cleaning config file %s: %s", s, err)
+		}
+	}
+}

--- a/cmd/eudico/mirvalidator/checkpoint.go
+++ b/cmd/eudico/mirvalidator/checkpoint.go
@@ -1,0 +1,144 @@
+package mirvalidator
+
+import (
+	"context"
+	"fmt"
+	_ "net/http/pprof"
+	"os"
+	"path/filepath"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/urfave/cli/v2"
+	"go.opencensus.io/tag"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/mir/pkg/checkpoint"
+
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/consensus/mir"
+	mirkv "github.com/filecoin-project/lotus/chain/consensus/mir/db/kv"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/metrics"
+)
+
+var checkCmd = &cli.Command{
+	Name:  "checkpoint",
+	Usage: "Manage Mir checkpoints",
+	Subcommands: []*cli.Command{
+		importCheckCmd,
+		exportCheckCmd,
+	},
+}
+
+var importCheckCmd = &cli.Command{
+	Name:  "import",
+	Usage: "Imports checkpoint from file",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "file",
+			Aliases: []string{"f"},
+			Usage:   "optionally specify the account used for the validator",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx, _ := tag.New(lcli.DaemonContext(cctx),
+			tag.Insert(metrics.Version, build.BuildVersion),
+			tag.Insert(metrics.Commit, build.CurrentCommit),
+			tag.Insert(metrics.NodeType, "miner"),
+		)
+
+		repoFlag := cctx.String("repo")
+		fileFlag := cctx.String("file")
+
+		// check if validator has been initialized.
+		if err := initCheck(repoFlag); err != nil {
+			return err
+		}
+
+		// Initialize Mir's DB.
+		dbPath := filepath.Join(repoFlag, LevelDSPath)
+		ds, err := mirkv.NewLevelDB(dbPath, false)
+		if err != nil {
+			return fmt.Errorf("error initializing mir datastore: %s", err)
+		}
+
+		_, err = checkpointFromFile(ctx, ds, fileFlag)
+		log.Infof("Import checkpoint from file %s", fileFlag)
+		return err
+	},
+}
+
+var exportCheckCmd = &cli.Command{
+	Name:  "export",
+	Usage: "Exports checkpoint to file",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "output",
+			Usage: "optionally specify the output for the checkpoint",
+		},
+		&cli.IntFlag{
+			Name:  "height",
+			Usage: "optionally specify the height for the checkpoint to export. If not specified the latest one will be exported",
+			Value: 0,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx, _ := tag.New(lcli.DaemonContext(cctx),
+			tag.Insert(metrics.Version, build.BuildVersion),
+			tag.Insert(metrics.Commit, build.CurrentCommit),
+			tag.Insert(metrics.NodeType, "miner"),
+		)
+
+		repoFlag := cctx.String("repo")
+
+		// check if validator has been initialized.
+		if err := initCheck(repoFlag); err != nil {
+			return err
+		}
+
+		// Initialize Mir's DB.
+		dbPath := filepath.Join(repoFlag, LevelDSPath)
+		ds, err := mirkv.NewLevelDB(dbPath, true)
+		if err != nil {
+			return fmt.Errorf("error initializing mir datastore: %s", err)
+		}
+
+		height := abi.ChainEpoch(cctx.Int("height"))
+		ch, err := mir.GetCheckpointByHeight(ctx, ds, height, nil)
+		if err != nil {
+			return fmt.Errorf("error getting checkpoint by height: %s", err)
+		}
+		path := cctx.String("file")
+		heightStr := height.String()
+		if path == "" {
+			if height == 0 {
+				heightStr = "latest"
+			}
+			path = "./checkpoint-height-" + heightStr + ".chkp"
+		}
+		log.Infof("Exporting checkpoint for height %s to file %s", heightStr, path)
+		return mir.CheckpointToFile(ch, path)
+	},
+}
+
+func checkpointFromFile(ctx context.Context, ds datastore.Datastore, path string) (*checkpoint.StableCheckpoint, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error checkpoint from file: %s", err)
+	}
+	ch := &checkpoint.StableCheckpoint{}
+	err = ch.Deserialize(b)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing checkpoint from file: %s", err)
+	}
+	snapshot := &mir.Checkpoint{}
+	if err := snapshot.FromBytes(ch.Snapshot.AppData); err != nil {
+		return nil, xerrors.Errorf("error getting checkpoint snapshot from mir checkpoint: %s", err)
+	}
+	// always flush the checkpoint in database when importing so we have posterior knowledge of it.
+	if err := ds.Put(ctx, mir.HeightCheckIndexKey(snapshot.Height), b); err != nil {
+		return nil, xerrors.Errorf("error flushing checkpoint for height %d in datastore: %w", snapshot.Height, err)
+	}
+	return ch, nil
+}

--- a/cmd/eudico/mirvalidator/init.go
+++ b/cmd/eudico/mirvalidator/init.go
@@ -1,0 +1,81 @@
+package mirvalidator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/filecoin-project/lotus/chain/consensus/mir"
+)
+
+var initCmd = &cli.Command{
+	Name:  "init",
+	Usage: "Initialize the config for a mir-validator",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "overwrite",
+			Usage:   "Overwrites existing validator config from repo. Use with caution!",
+			Aliases: []string{"f"},
+			Value:   false,
+		},
+		&cli.StringFlag{
+			Name:  "membership",
+			Usage: "Pass membership config with the list of validator in the validator set",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		// check if repo initialized
+		if err := repoInitialized(context.Background(), cctx); err != nil {
+			return err
+		}
+		if cctx.Bool("overwrite") {
+			cleanConfig(cctx.String("repo"))
+		} else {
+			// check if validator has been initialized.
+			isCfg, err := isConfigured(cctx.String("repo"))
+			if err == nil {
+				return fmt.Errorf("validator already configured. Run `./mir-validator config init -f` if you want to overwrite the current config")
+			}
+			if isCfg && err != nil {
+				return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./mir-validator init -f`", err)
+			}
+		}
+
+		// TODO: Allow passing libp2p ID config as a parameter.
+		_, err := newLp2pHost(cctx.String("repo"))
+		if err != nil {
+			return fmt.Errorf("couldn't initialize libp2p config: %s", err)
+		}
+
+		// TODO: Pass validator set for initialization
+		mp := path.Join(cctx.String("repo"), MembershipCfgPath)
+		if cctx.String("membership") != "" {
+			validators, err := mir.GetValidatorsFromFile(cctx.String("membership"))
+			if err != nil {
+				return fmt.Errorf("error importing membership config specified: %s", err)
+			}
+			// persist validator config in the right path.
+			if err := mir.ValidatorsToCfg(validators, mp); err != nil {
+				return fmt.Errorf("error exporting membership config: %s", err)
+			}
+		} else {
+			log.Infof("Creating empty membership cfg at %s. Remember to run ./mir-validator add-validator to add more membership validators", mp)
+			if _, err := os.Create(mp); err != nil {
+				return fmt.Errorf("error creating empty membership config in %s", mp)
+			}
+		}
+
+		// initialize database path
+		datastoreCfg := filepath.Join(cctx.String("repo"), LevelDSPath)
+		if err := os.MkdirAll(datastoreCfg, 0755); err != nil {
+			return fmt.Errorf("error initializing mir datastore in path %s: %s", LevelDSPath, err)
+		}
+
+		log.Infow("Initialized mir validator. Run ./mir-validator run to start validator process")
+		return nil
+	},
+}

--- a/cmd/eudico/mirvalidator/run.go
+++ b/cmd/eudico/mirvalidator/run.go
@@ -1,0 +1,198 @@
+package mirvalidator
+
+import (
+	"context"
+	_ "net/http/pprof"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/mir/pkg/checkpoint"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/api/v0api"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/consensus/mir"
+	mirkv "github.com/filecoin-project/lotus/chain/consensus/mir/db/kv"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/filecoin-project/lotus/eudico-core/global"
+	"github.com/filecoin-project/lotus/lib/ulimit"
+	"github.com/filecoin-project/lotus/metrics"
+)
+
+var runCmd = &cli.Command{
+	Name:  "run",
+	Usage: "Start a mir validator process",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "default-key",
+			Value: true,
+			Usage: "use default wallet's key",
+		},
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "optionally specify the account used for the validator",
+		},
+		&cli.BoolFlag{
+			Name:  "nosync",
+			Usage: "don't check full-node sync status",
+		},
+		&cli.BoolFlag{
+			Name:  "manage-fdlimit",
+			Usage: "manage open file limit",
+			Value: true,
+		},
+		&cli.IntFlag{
+			Name:  "init-height",
+			Usage: "checkpoint height from which to start the validator",
+			Value: 0,
+		},
+		&cli.StringFlag{
+			Name:  "init-checkpoint",
+			Usage: "pass initial checkpoint as a file (it overwrites 'init-height' flag)",
+		},
+		&cli.IntFlag{
+			Name:  "checkpoint-period",
+			Usage: "Checkpoint period",
+			Value: 8,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		api.RunningNodeType = api.NodeMiner
+		global.SetConsensusAlgorithm(global.MirConsensus)
+
+		ctx, _ := tag.New(lcli.DaemonContext(cctx),
+			tag.Insert(metrics.Version, build.BuildVersion),
+			tag.Insert(metrics.Commit, build.CurrentCommit),
+			tag.Insert(metrics.NodeType, "miner"),
+		)
+		// Register all metric views
+		if err := view.Register(
+			metrics.MinerNodeViews...,
+		); err != nil {
+			log.Fatalf("Cannot register the view: %v", err)
+		}
+		// Set the metric to one so it is published to the exporter
+		stats.Record(ctx, metrics.LotusInfo.M(1))
+
+		nodeApi, ncloser, err := lcli.GetFullNodeAPIV1(cctx)
+		if err != nil {
+			return xerrors.Errorf("getting full node api: %w", err)
+		}
+		defer ncloser()
+
+		v, err := nodeApi.Version(ctx)
+		if err != nil {
+			return err
+		}
+
+		// check if validator has been initialized.
+		if err := initCheck(cctx.String("repo")); err != nil {
+			return err
+		}
+
+		if cctx.Bool("manage-fdlimit") {
+			if _, _, err := ulimit.ManageFdLimit(); err != nil {
+				log.Errorf("setting file descriptor limit: %s", err)
+			}
+		}
+
+		if v.APIVersion != api.FullAPIVersion1 {
+			return xerrors.Errorf("lotus-daemon API version doesn't match: expected: %s", api.APIVersion{APIVersion: api.FullAPIVersion1})
+		}
+
+		log.Info("Checking full node sync status")
+
+		if !cctx.Bool("nosync") {
+			if err := lcli.SyncWait(ctx, &v0api.WrapperV1Full{FullNode: nodeApi}, false); err != nil {
+				return xerrors.Errorf("sync wait: %w", err)
+			}
+		}
+
+		// Validator identity.
+		validator, err := validatorIDFromFlag(ctx, cctx, nodeApi)
+		if err != nil {
+			return err
+		}
+
+		// Membership config.
+		// TODO: Make this configurable.
+		membershipCfg := filepath.Join(cctx.String("repo"), MembershipCfgPath)
+
+		// Checkpoint period.
+		checkpointPeriod := cctx.Int("checkpoint-period")
+
+		h, err := newLp2pHost(cctx.String("repo"))
+		if err != nil {
+			return err
+		}
+
+		log.Info("Mir libp2p host listening in the following addresses:")
+		for _, a := range h.Addrs() {
+			log.Info(a)
+		}
+
+		// Initialize Mir's DB.
+		dbPath := filepath.Join(cctx.String("repo"), LevelDSPath)
+		ds, err := mirkv.NewLevelDB(dbPath, false)
+		if err != nil {
+			return xerrors.Errorf("error initializing mir datastore: %w", err)
+		}
+
+		// get initial checkpoint
+		var initCh *checkpoint.StableCheckpoint
+		if cctx.String("init-checkpoint") != "" {
+			initCh, err = checkpointFromFile(ctx, ds, cctx.String("init-checkpoint"))
+			if err != nil {
+				return xerrors.Errorf("failed to get initial checkpoint from file: %s", err)
+			}
+			log.Info("Initializing mir validator from checkpoint provided in file: %s", cctx.String("init-checkpoint"))
+		} else if cctx.Int("init-height") != 0 {
+			initCh, err = mir.GetCheckpointByHeight(ctx, ds, abi.ChainEpoch(cctx.Int("init-height")), nil)
+			if err != nil {
+				return xerrors.Errorf("failed to get initial checkpoint from file: %s", err)
+			}
+			log.Info("Initializing mir validator from checkpoint in height: %d", cctx.Int("init-height"))
+		}
+
+		log.Infow("Starting mining with validator", "validator", validator)
+		cfg := mir.NewConfig(
+			mir.MembershipFromFile(membershipCfg),
+			dbPath,
+			checkpointPeriod,
+			initCh,
+			cctx.String("checkpoints-repo"))
+		return mir.Mine(ctx, validator, h, nodeApi, ds, cfg)
+	},
+}
+
+func validatorIDFromFlag(ctx context.Context, cctx *cli.Context, nodeApi api.FullNode) (address.Address, error) {
+	var (
+		validator address.Address
+		err       error
+	)
+
+	if cctx.Bool("default-key") {
+		validator, err = nodeApi.WalletDefaultAddress(ctx)
+		if err != nil {
+			return address.Undef, err
+		}
+	}
+	if cctx.String("from") != "" {
+		validator, err = address.NewFromString(cctx.String("from"))
+		if err != nil {
+			return address.Undef, err
+		}
+	}
+	if validator == address.Undef {
+		return address.Undef, xerrors.Errorf("no validator address specified as first argument for validator")
+	}
+
+	return validator, nil
+}

--- a/cmd/eudico/mirvalidator/utils.go
+++ b/cmd/eudico/mirvalidator/utils.go
@@ -1,0 +1,195 @@
+package mirvalidator
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
+	lcli "github.com/filecoin-project/lotus/cli"
+)
+
+var log = logging.Logger("mir-validator-cli")
+
+func repoInitialized(ctx context.Context, cctx *cli.Context) error {
+	_, ncloser, err := lcli.GetFullNodeAPIV1(cctx)
+	if err != nil {
+		return xerrors.Errorf("checking api to see if repo initialized: %w", err)
+	}
+	defer ncloser()
+	return nil
+
+}
+func initCheck(path string) error {
+	isCfg, err := isConfigured(path)
+	if err != nil {
+		if isCfg {
+			return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./mir-validator init -f`", err)
+		}
+		return fmt.Errorf("validator not configured. Run `./mir-validator config init`")
+	}
+	return nil
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// returns an error if the validator is not configured.
+func isConfigured(repo string) (bool, error) {
+	// FIXME: If we make these constants configurable it will break this.
+	// careful with this!
+	hasCfg := false
+	for _, s := range configFiles {
+		p := filepath.Join(repo, s)
+		ok, err := fileExists(p)
+		if err != nil {
+			return hasCfg, err
+		}
+		if !ok {
+			return hasCfg, fmt.Errorf("missing %v config file", p)
+		}
+		// if it has at least one config file, it has been configured
+		// but something is corrupted.
+		hasCfg = true
+	}
+	return hasCfg, nil
+}
+
+// TODO: Consider encrypting the file and adding cmds to handle mir keys.
+func lp2pID(dir string) (crypto.PrivKey, error) {
+	// See if the key exists.
+	path := filepath.Join(dir, PrivKeyPath)
+	// if it doesn't exist create a new key
+	exists, err := fileExists(path)
+	if !exists {
+		pk, err := genLibp2pKey()
+		if err != nil {
+			return nil, fmt.Errorf("error generating libp2p key: %w", err)
+		}
+		file, err := os.Create(path)
+		if err != nil {
+			return nil, fmt.Errorf("error creating libp2p key: %w", err)
+		}
+		kbytes, err := crypto.MarshalPrivateKey(pk)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling libp2p key: %w", err)
+		}
+		_, err = file.Write(kbytes)
+		if err != nil {
+			return nil, fmt.Errorf("error writing libp2p key in file: %w", err)
+		}
+		return pk, nil
+	}
+	kbytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading libp2p key from file: %w", err)
+	}
+
+	// if read and return the key.
+	return crypto.UnmarshalPrivateKey(kbytes)
+}
+
+func genLibp2pKey() (crypto.PrivKey, error) {
+	pk, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return pk, nil
+}
+
+// TODO: Should we make multiaddrs configurable?
+func newLp2pHost(dir string) (host.Host, error) {
+	pk, err := lp2pID(dir)
+	if err != nil {
+		return nil, err
+	}
+	// See if mutiaddr exists.
+	path := filepath.Join(dir, MaddrPath)
+	// if it doesn't exist create a new key
+	exists, err := fileExists(path)
+	if !exists {
+		// use any free endpoints in the host.
+		h, err := libp2p.New(
+			libp2p.Identity(pk),
+			libp2p.DefaultTransports,
+			libp2p.ListenAddrStrings(
+				"/ip4/0.0.0.0/tcp/0",
+				"/ip6/::/tcp/0",
+				"/ip4/0.0.0.0/udp/0/quic",
+				"/ip6/::/udp/0/quic"),
+		)
+		if err != nil {
+			return nil, err
+		}
+		file, err := os.Create(path)
+		if err != nil {
+			return nil, fmt.Errorf("error creating libp2p multiaddr: %w", err)
+		}
+		b, err := marshalMultiAddrSlice(h.Addrs())
+		if err != nil {
+			return nil, err
+		}
+		_, err = file.Write(b)
+		if err != nil {
+			return nil, fmt.Errorf("error writing libp2p multiaddr in file: %w", err)
+		}
+		return h, nil
+	}
+	bMaddr, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading multiaddr from file: %w", err)
+	}
+
+	addrs, err := unmarshalMultiAddrSlice(bMaddr)
+	if err != nil {
+		return nil, err
+	}
+	return libp2p.New(
+		libp2p.Identity(pk),
+		libp2p.DefaultTransports,
+		libp2p.ListenAddrs(addrs...),
+	)
+}
+
+func marshalMultiAddrSlice(ma []multiaddr.Multiaddr) ([]byte, error) {
+	out := []string{}
+	for _, a := range ma {
+		out = append(out, a.String())
+	}
+	return json.Marshal(&out)
+}
+
+func unmarshalMultiAddrSlice(b []byte) ([]multiaddr.Multiaddr, error) {
+	out := []multiaddr.Multiaddr{}
+	s := []string{}
+	if err := json.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	for _, mstr := range s {
+		a, err := multiaddr.NewMultiaddr(mstr)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}

--- a/cmd/eudico/mirvalidator/validator.go
+++ b/cmd/eudico/mirvalidator/validator.go
@@ -1,0 +1,25 @@
+package mirvalidator
+
+import (
+	"github.com/urfave/cli/v2"
+
+	cliutil "github.com/filecoin-project/lotus/cli/util"
+)
+
+var ValidatorCmd = &cli.Command{
+	Name:  "validator",
+	Usage: "Run and manage a mir validator process",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "checkpoints-repo",
+			EnvVars: []string{"CHECKPOINTS_REPO"},
+			Hidden:  true,
+		},
+		cliutil.FlagVeryVerbose,
+	},
+	Subcommands: []*cli.Command{
+		runCmd,
+		cfgCmd,
+		checkCmd,
+	},
+}

--- a/cmd/mir-validator/main.go
+++ b/cmd/mir-validator/main.go
@@ -19,7 +19,7 @@ import (
 var log = logging.Logger("mir-validator-cli")
 
 func main() {
-	api.RunningNodeType = api.NodeFull
+	api.RunningNodeType = api.NodeMiner
 
 	lotuslog.SetupLogLevels()
 

--- a/cmd/mir-validator/main.go
+++ b/cmd/mir-validator/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/fatih/color"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
 
@@ -44,6 +45,10 @@ func main() {
 				_ = jaeger.Shutdown(cctx.Context)
 			}
 			jaeger = tracing.SetupJaegerTracing("lotus/" + cmd.Name)
+
+			if cctx.IsSet("color") {
+				color.NoColor = !cctx.Bool("color")
+			}
 
 			if originBefore != nil {
 				return originBefore(cctx)

--- a/cmd/mir-validator/main.go
+++ b/cmd/mir-validator/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/fatih/color"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
 
@@ -20,7 +19,7 @@ import (
 var log = logging.Logger("mir-validator-cli")
 
 func main() {
-	api.RunningNodeType = api.NodeMiner
+	api.RunningNodeType = api.NodeFull
 
 	lotuslog.SetupLogLevels()
 
@@ -45,10 +44,6 @@ func main() {
 				_ = jaeger.Shutdown(cctx.Context)
 			}
 			jaeger = tracing.SetupJaegerTracing("lotus/" + cmd.Name)
-
-			if cctx.IsSet("color") {
-				color.NoColor = !cctx.Bool("color")
-			}
 
 			if originBefore != nil {
 				return originBefore(cctx)

--- a/scripts/mir/daemon.sh
+++ b/scripts/mir/daemon.sh
@@ -28,7 +28,7 @@ rm -rf $LOTUS_PATH
 # then
 #   # Remove the previous genesis so we don´t get a race if we try to start a daemon before generating the genesis from daemon 0.
 #    rm ./scripts/mir/devgen.car
-#    ./lotus daemon --lotus-make-genesis=./scripts/mir/devgen.car --genesis-template=./scripts/mir/localnet.json --bootstrap=false --api=123$INDEX --mir-validator
+#    ./eudico mir daemon --lotus-make-genesis=./scripts/mir/devgen.car --genesis-template=./scripts/mir/localnet.json --bootstrap=false --api=123$INDEX
 # else
-./bin/eudico mir daemon --genesis=./scripts/mir/devgen.car --bootstrap=false --api=123$INDEX
+./eudico mir daemon --genesis=./scripts/mir/devgen.car --bootstrap=false --api=123$INDEX
 # fi

--- a/scripts/mir/validator.sh
+++ b/scripts/mir/validator.sh
@@ -18,10 +18,10 @@ export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
 export CGO_CFLAGS="-D__BLST_PORTABLE__"
 export GOLOG_LOG_LEVEL=$LOG_LEVEL
 
-./bin/eudico wait-api
+./eudico wait-api
 
 # Copy mir config and import keys
-./bin/eudico wallet import --as-default --format=json-lotus  ./scripts/mir/mir-config/node$INDEX/wallet.key
+./eudico wallet import --as-default --format=json-lotus  ./scripts/mir/mir-config/node$INDEX/wallet.key
 cp ./scripts/mir/mir-config/node$INDEX/* $LOTUS_PATH
 mkdir $LOTUS_PATH/mir.db
 
@@ -30,6 +30,5 @@ n=$(cat mir-event-logs/counter)
 export MIR_INTERCEPTOR_OUTPUT="mir-event-logs/run-${n}"
 echo $((n + 1)) > mir-event-logs/counter
 
-# Compile and run validator
-# make mir-validator
-./mir-validator run --nosync 
+# Run validator
+./eudico mir validator run --nosync


### PR DESCRIPTION
This PR moves the commands available in the `mir-validator` into the `eudico` binary. It also updates the scripts accordingly.