### PR TITLE
Update Makefile and cmd to use eudico instead of lotus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ debug: build-devnets
 2k: build-devnets
 
 spacenet: GOFLAGS+=-tags=spacenet
-spacenet: eudico lotus mir-validator lotus-seed lotus-keygen lotus-shed
+spacenet: eudico lotus-seed lotus-keygen lotus-shed
 
 spacenet-test: GOFLAGS+=-tags=spacenet
 spacenet-test:

--- a/cmd/eudico/daemon.go
+++ b/cmd/eudico/daemon.go
@@ -135,6 +135,14 @@ func daemonCmd(consensusAlgorithm global.ConsensusAlgorithm) *cli.Command {
 				Name:  "restore-config",
 				Usage: "config file to use when restoring from backup",
 			},
+			&cli.BoolFlag{
+				Name:  "lite",
+				Usage: "start lotus in lite mode",
+			},
+			&cli.BoolFlag{
+				Name:  "mir-validator",
+				Usage: "start lotus in mir-validator mode",
+			},
 		},
 		Action: eudicoDaemonAction(consensusAlgorithm),
 		Subcommands: []*cli.Command{

--- a/cmd/eudico/mirvalidator/init.go
+++ b/cmd/eudico/mirvalidator/init.go
@@ -38,10 +38,10 @@ var initCmd = &cli.Command{
 			// check if validator has been initialized.
 			isCfg, err := isConfigured(cctx.String("repo"))
 			if err == nil {
-				return fmt.Errorf("validator already configured. Run `./mir-validator config init -f` if you want to overwrite the current config")
+				return fmt.Errorf("validator already configured. Run `./eudico mir validator config init -f` if you want to overwrite the current config")
 			}
 			if isCfg && err != nil {
-				return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./mir-validator init -f`", err)
+				return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./eudico mir validator init -f`", err)
 			}
 		}
 
@@ -63,7 +63,7 @@ var initCmd = &cli.Command{
 				return fmt.Errorf("error exporting membership config: %s", err)
 			}
 		} else {
-			log.Infof("Creating empty membership cfg at %s. Remember to run ./mir-validator add-validator to add more membership validators", mp)
+			log.Infof("Creating empty membership cfg at %s. Remember to run ./eudico mir validator add-validator to add more membership validators", mp)
 			if _, err := os.Create(mp); err != nil {
 				return fmt.Errorf("error creating empty membership config in %s", mp)
 			}
@@ -75,7 +75,7 @@ var initCmd = &cli.Command{
 			return fmt.Errorf("error initializing mir datastore in path %s: %s", LevelDSPath, err)
 		}
 
-		log.Infow("Initialized mir validator. Run ./mir-validator run to start validator process")
+		log.Infow("Initialized mir validator. run ./eudico mir validator run to start validator process")
 		return nil
 	},
 }

--- a/cmd/eudico/mirvalidator/utils.go
+++ b/cmd/eudico/mirvalidator/utils.go
@@ -35,9 +35,9 @@ func initCheck(path string) error {
 	isCfg, err := isConfigured(path)
 	if err != nil {
 		if isCfg {
-			return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./mir-validator init -f`", err)
+			return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./eudico mir validator init -f`", err)
 		}
-		return fmt.Errorf("validator not configured. Run `./mir-validator config init`")
+		return fmt.Errorf("validator not configured. Run `./eudico mir validator config init`")
 	}
 	return nil
 }

--- a/cmd/mir-validator/README.md
+++ b/cmd/mir-validator/README.md
@@ -6,11 +6,11 @@ Use `make mir-validator` or `make spacenet` to compile the application. To
 run a validator you need to:
 - First spawn a lotus-daemon.
 - Initialize the configuration of mir-validator in $LOTUS_PATH. Be sure to have your $LOTUS_PATH set to the right directory, or it will use the default repo directory (`~/.lotus`).
-`./mir-validator config init`
+`./eudico mir validator config init`
 - The information about the validators membership for the network is currently stored
 in `$LOTUS_PATH/mir.validators`. To add new validators to the membership list you can either
-paste the information of the new validator in that file (with the format `<wallet_addr>@<multiaddr_with_/p2p_info>`), or run `./mir-validator config add-validator`.
-- Run the validator process using `./mir-validator run --nosync`
+paste the information of the new validator in that file (with the format `<wallet_addr>@<multiaddr_with_/p2p_info>`), or run `./eudico mir validator config add-validator`.
+- Run the validator process using `./eudico mir validator run --nosync`
 
 ## Persisting Mir checkpoints
 Mir relies on the use of checkpoints to recover validators after a failure, and to allow full-nodes (or as we like to call them, _learners_) to verify the validity of blocks received through the network. Learners are not participating from the block validation process, and checkpoints are the only way for them to verify that the blocks received.
@@ -20,19 +20,19 @@ If you want to persist every checkpoint produced by mir in a specific path of yo
 Alternatively, if by any chance you are not persisting these checkpoints in `$CHECKPOINTS_REPO` and you want to access them at some point, checkpoints are also persisted in the validator's database. To import and export a checkpoint from and to your validator's database you can use the following commands: 
 ```
 # Import a checkpoint from a file
-./mir-validator checkpoint --file <checkpoint_file>
+./eudico mir validator checkpoint --file <checkpoint_file>
 
 # Export latst checkpoint to file from database
-./mir-validator checkpoint export --output <output-file>
+./eudico mir validator checkpoint export --output <output-file>
 
 # Export checkpoint for specific height
-./mir-validator checkpoint export --height <height>
+./eudico mir validator checkpoint export --height <height>
 ```
 
-> NOTE: `./mir-validator checkpoint` can't be use when the validator is running. These commands insantiate the validator database to access the checkpoints, so they can only be used when the validator is stopped. They are provided to be used when a validator fails (or is shut down) and checkpoints from the validator need to be recovered. If in the future there is a lot of demand for these commands to be available while the validator is running we'll add this feature (so let us know :) ).
+> NOTE: `./eudico mir validator checkpoint` can't be use when the validator is running. These commands insantiate the validator database to access the checkpoints, so they can only be used when the validator is stopped. They are provided to be used when a validator fails (or is shut down) and checkpoints from the validator need to be recovered. If in the future there is a lot of demand for these commands to be available while the validator is running we'll add this feature (so let us know :) ).
 
 ## Restarting a validator
-Validators can be restarted seamlessly by running again `./mir-validator run --nosync`. The validator itself will request the latest checkpoint to other validators and sync its state until it catches up and is able to participate from the consensus again. Alternatively, we may restart a validator from a specific checkpoint by providing the `--init-height` and `--init-checkpoint` flags to initialize the validator from a checkpoint at a specific hegiht, or from a checkpoint file, respectively.
+Validators can be restarted seamlessly by running again `./eudico mir validator run --nosync`. The validator itself will request the latest checkpoint to other validators and sync its state until it catches up and is able to participate from the consensus again. Alternatively, we may restart a validator from a specific checkpoint by providing the `--init-height` and `--init-checkpoint` flags to initialize the validator from a checkpoint at a specific hegiht, or from a checkpoint file, respectively.
 
 For a validator to be able to recover its state successfully, it needs to have its Lotus daemon running, and its daemon needs to be connected to at least some other Lotus daemon in the network with the latest state (ideally another synced validator). The validator will fail to start if it doesn't find any good peer to sync from.
 
@@ -48,6 +48,6 @@ The following steps should be followed in every validator to recover a network f
 - Once the lotus daemon has been initialized from the right state, we just need to start the mir-validator from the right checkpoint.
 ```
 # Start validator from checkpoint
-./mir-validator run --nosync --init-checkpoint=<checkpoint_file>
+./eudico mir validator run --nosync --init-checkpoint=<checkpoint_file>
 ```
 Once all `f+1` are restarted with the same state, you should start seeing how the validators start making progress from the height where they were initialized.

--- a/cmd/mir-validator/README.md
+++ b/cmd/mir-validator/README.md
@@ -29,7 +29,7 @@ Alternatively, if by any chance you are not persisting these checkpoints in `$CH
 ./eudico mir validator checkpoint export --height <height>
 ```
 
-> NOTE: `./eudico mir validator checkpoint` can't be use when the validator is running. These commands insantiate the validator database to access the checkpoints, so they can only be used when the validator is stopped. They are provided to be used when a validator fails (or is shut down) and checkpoints from the validator need to be recovered. If in the future there is a lot of demand for these commands to be available while the validator is running we'll add this feature (so let us know :) ).
+> NOTE: `./eudico mir validator checkpoint` can't be used when the validator is running. These commands insantiate the validator database to access the checkpoints, so they can only be used when the validator is stopped. They are provided to be used when a validator fails (or is shut down) and checkpoints from the validator need to be recovered. If in the future there is a lot of demand for these commands to be available while the validator is running we'll add this feature (so let us know :) ).
 
 ## Restarting a validator
 Validators can be restarted seamlessly by running again `./eudico mir validator run --nosync`. The validator itself will request the latest checkpoint to other validators and sync its state until it catches up and is able to participate from the consensus again. Alternatively, we may restart a validator from a specific checkpoint by providing the `--init-height` and `--init-checkpoint` flags to initialize the validator from a checkpoint at a specific hegiht, or from a checkpoint file, respectively.

--- a/cmd/mir-validator/init.go
+++ b/cmd/mir-validator/init.go
@@ -38,10 +38,10 @@ var initCmd = &cli.Command{
 			// check if validator has been initialized.
 			isCfg, err := isConfigured(cctx.String("repo"))
 			if err == nil {
-				return fmt.Errorf("validator already configured. Run `./mir-validator config init -f` if you want to overwrite the current config")
+				return fmt.Errorf("validator already configured. Run `./eudico mir validator config init -f` if you want to overwrite the current config")
 			}
 			if isCfg && err != nil {
-				return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./mir-validator init -f`", err)
+				return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./eudico mir validator init -f`", err)
 			}
 		}
 
@@ -63,7 +63,7 @@ var initCmd = &cli.Command{
 				return fmt.Errorf("error exporting membership config: %s", err)
 			}
 		} else {
-			log.Infof("Creating empty membership cfg at %s. Remember to run ./mir-validator add-validator to add more membership validators", mp)
+			log.Infof("Creating empty membership cfg at %s. Remember to run ./eudico mir validator add-validator to add more membership validators", mp)
 			if _, err := os.Create(mp); err != nil {
 				return fmt.Errorf("error creating empty membership config in %s", mp)
 			}
@@ -75,7 +75,7 @@ var initCmd = &cli.Command{
 			return fmt.Errorf("error initializing mir datastore in path %s: %s", LevelDSPath, err)
 		}
 
-		log.Infow("Initialized mir validator. Run ./mir-validator run to start validator process")
+		log.Infow("Initialized mir validator. Run ./eudico mir validator run to start validator process")
 		return nil
 	},
 }

--- a/cmd/mir-validator/utils.go
+++ b/cmd/mir-validator/utils.go
@@ -32,9 +32,9 @@ func initCheck(path string) error {
 	isCfg, err := isConfigured(path)
 	if err != nil {
 		if isCfg {
-			return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./mir-validator init -f`", err)
+			return fmt.Errorf("validator configured and config corrupted: %v. Backup the config files you want to keep and run `./eudico mir validator init -f`", err)
 		}
-		return fmt.Errorf("validator not configured. Run `./mir-validator config init`")
+		return fmt.Errorf("validator not configured. Run `./eudico mir validator config init`")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR includes some housekeeping to start the migration from Lotus to Eudico in preparation for Spacenet upgrade.
- It removes `lotus` and `mir-validator` from `make spacenet`.
- It updates the `mir-validator` README and other references to the binary to use `eudico` instead of `mir-validator`
- It adds the required flags for `--lite` and `--mir-validator` to the eudico binary.
