### PR TITLE
Fix logging level in itests

### DIFF
--- a/itests/kit/init.go
+++ b/itests/kit/init.go
@@ -14,7 +14,9 @@ import (
 )
 
 func init() {
-	_ = logging.SetLogLevel("*", "INFO")
+	if _, set := os.LookupEnv("GOLOG_LOG_LEVEL"); !set {
+		_ = logging.SetLogLevel("*", "INFO")
+	}
 
 	// These values mimic the values set in the builtin-actors when configured to use the "testing" network. Specifically:
 	// - All proof types.


### PR DESCRIPTION
Without this PR it is not possible to control the logging level in itests: all logged messages are INFO and higher even if you want to customize them via GOLOG_LOG_LEVEL.