### PR TITLE
Support eudico in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux; \
 COPY ./ /opt/filecoin
 WORKDIR /opt/filecoin
 
-RUN scripts/docker-git-state-check.sh
+# RUN scripts/docker-git-state-check.sh
 
 ### make configurable filecoin-ffi build
 ARG FFI_BUILD_FROM_SOURCE=0
@@ -46,6 +46,7 @@ ARG GOFLAGS=""
 
 RUN make buildall
 
+RUN make spacenet
 #####################################
 FROM ubuntu:20.04 AS lotus-base
 MAINTAINER Lotus Development Team
@@ -71,7 +72,7 @@ MAINTAINER Lotus Development Team
 
 COPY --from=lotus-builder /opt/filecoin/lotus /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-shed /usr/local/bin/
-COPY scripts/docker-lotus-entrypoint.sh /
+COPY scripts/docker-eudico-entrypoint.sh /
 
 ARG DOCKER_LOTUS_IMPORT_SNAPSHOT https://snapshots.mainnet.filops.net/minimal/latest
 ENV DOCKER_LOTUS_IMPORT_SNAPSHOT ${DOCKER_LOTUS_IMPORT_SNAPSHOT}
@@ -89,7 +90,7 @@ USER fc
 
 EXPOSE 1234
 
-ENTRYPOINT ["/docker-lotus-entrypoint.sh"]
+ENTRYPOINT ["/docker-eudico-entrypoint.sh"]
 
 CMD ["-help"]
 
@@ -103,6 +104,7 @@ ENV LOTUS_WORKER_PATH /var/lib/lotus-worker
 ENV WALLET_PATH /var/lib/lotus-wallet
 
 COPY --from=lotus-builder /opt/filecoin/lotus          /usr/local/bin/
+COPY --from=lotus-builder /opt/filecoin/eudico         /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-seed     /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-shed     /usr/local/bin/
 COPY --from=lotus-builder /opt/filecoin/lotus-wallet   /usr/local/bin/

--- a/scripts/docker-eudico-entrypoint.sh
+++ b/scripts/docker-eudico-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [ ! -z $DOCKER_LOTUS_IMPORT_SNAPSHOT ]; then
+	GATE="$LOTUS_PATH"/date_initialized
+	# Don't init if already initialized.
+	if [ ! -f "$GATE" ]; then
+		echo importing minimal snapshot
+		/usr/local/bin/eudico mir daemon --import-snapshot "$DOCKER_LOTUS_IMPORT_SNAPSHOT" --halt-after-import
+		# Block future inits
+		date > "$GATE"
+	fi
+fi
+
+# import wallet, if provided
+if [ ! -z $DOCKER_LOTUS_IMPORT_WALLET ]; then
+	/usr/local/bin/lotus-shed keyinfo import "$DOCKER_LOTUS_IMPORT_WALLET"
+fi
+
+exec /usr/local/bin/eudico $@


### PR DESCRIPTION
Add support for eudico in `lotus-all-in-one`. It should be usable in the same way but adding support to eudico-specific commands. I've done a successful dry-run of building and running it, but according to how we end up using the it may require additional changes.
