### PR TITLE
Integrate new genesis in spacenet binary

### DIFF
--- a/scripts/mir/localnet.json
+++ b/scripts/mir/localnet.json
@@ -35,6 +35,13 @@
       "Meta": {
           "Owner": "t12zjpclnis2uytmcydrx7i5jcbvehs5ut3x6mvvq"
       }
+  },
+      {
+      "Type": "account",
+      "Balance": "500000000000000000000000000",
+      "Meta": {
+          "Owner": "f1jlm55oqkdalh2l3akqfsaqmpjxgjd36pob34dqy"
+      }
   }
   ],
   "Miners": [


### PR DESCRIPTION
To easily generate an up-to-date version of the spacenet genesis one can run the following command. We could probably include it on a Makefile rule. 
```
rm -rf ~/.lotus && ./eudico mir daemon --eudico-make-genesis=./build/genesis/spacenet.car --genesis-template=./scripts/mir/localnet.json
```

/cc @TippyFlitsUK 