### PR TITLE
Remove check that validators do not mine blocks when disconnected

### DIFF
--- a/itests/kit/mir_tools.go
+++ b/itests/kit/mir_tools.go
@@ -79,39 +79,6 @@ func AdvanceChain(ctx context.Context, blocks int, nodes ...*TestFullNode) error
 	return g.Wait()
 }
 
-// NoProgressForFaultyNodes checks that the heights of the faulty nodes are not changed after advancing the chain.
-func NoProgressForFaultyNodes(ctx context.Context, blocks int, nodes []*TestFullNode, faultyNodes ...*TestFullNode) error {
-	oldHeights := make([]abi.ChainEpoch, len(faultyNodes))
-
-	time.Sleep(1 * time.Second)
-
-	for i, fn := range faultyNodes {
-		ts, err := ChainHeadWithCtx(ctx, fn.FullNode)
-		if err != nil {
-			return err
-		}
-		oldHeights[i] = ts.Height()
-	}
-
-	err := AdvanceChain(ctx, blocks, nodes...)
-	if err != nil {
-		return err
-	}
-
-	for i, fn := range faultyNodes {
-		ts, err := ChainHeadWithCtx(ctx, fn.FullNode)
-		if err != nil {
-			return err
-		}
-		newHeight := ts.Height()
-		if newHeight != oldHeights[i] {
-			return fmt.Errorf("validator %d chain height updated: new - %d, old - %d", i, newHeight, oldHeights[i])
-		}
-	}
-
-	return nil
-}
-
 // WaitForMessageWithAvailable is a wrapper on StateWaitMsg that looks back up to limit epochs in the chain for a message.
 //
 // We need to wrap `StateWaitMsg` in this function in case the `GetCMessage` inside `StateWaitMsg` fails.

--- a/itests/mir_test.go
+++ b/itests/mir_test.go
@@ -1063,13 +1063,7 @@ func TestMirBasic_WithFOmissionNodes(t *testing.T) {
 	ens.DisconnectNodes(nodes[:MirFaultyValidatorNumber], nodes[MirFaultyValidatorNumber:])
 	ens.DisconnectMirValidators(ctx, validators[:MirFaultyValidatorNumber])
 
-	for _, node := range nodes[:MirFaultyValidatorNumber] {
-		peers, err := node.NetPeers(ctx)
-		require.NoError(t, err)
-		require.Equal(t, 0, kit.CountPeerIDs(peers))
-	}
-
-	err = kit.NoProgressForFaultyNodes(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:], nodes[:MirFaultyValidatorNumber]...)
+	err = kit.AdvanceChain(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
 	require.NoError(t, err)
 
 	t.Logf(">>> reconnecting %d nodes", MirFaultyValidatorNumber)
@@ -1111,7 +1105,7 @@ func TestMirBasic_WithFCrashedNodes(t *testing.T) {
 	t.Logf(">>> crash %d validators", MirFaultyValidatorNumber)
 	ens.CrashMirValidators(ctx, 0, validators[:MirFaultyValidatorNumber]...)
 
-	err = kit.NoProgressForFaultyNodes(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:], nodes[:MirFaultyValidatorNumber]...)
+	err = kit.AdvanceChain(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
 	require.NoError(t, err)
 
 	t.Logf(">>> restore %d validators", MirFaultyValidatorNumber)
@@ -1154,7 +1148,7 @@ func TestMirBasic_WithFRestartedNodes(t *testing.T) {
 	t.Logf(">>> restart %d validators", MirFaultyValidatorNumber)
 	ens.RestartMirValidators(ctx, 0, validators[:MirFaultyValidatorNumber]...)
 
-	err = kit.NoProgressForFaultyNodes(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:], nodes[:MirFaultyValidatorNumber]...)
+	err = kit.AdvanceChain(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
 	require.NoError(t, err)
 
 	t.Logf(">>> restore %d validators", MirFaultyValidatorNumber)
@@ -1284,7 +1278,7 @@ func TestMirBasic_WithFCrashedAndRecoveredNodes(t *testing.T) {
 	t.Logf(">>> crash %d validators", MirFaultyValidatorNumber)
 	ens.CrashMirValidators(ctx, 0, validators[:MirFaultyValidatorNumber]...)
 
-	err = kit.NoProgressForFaultyNodes(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:], nodes[:MirFaultyValidatorNumber]...)
+	err = kit.AdvanceChain(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
 	require.NoError(t, err)
 
 	t.Logf(">>> restore %d validators from scratch", MirFaultyValidatorNumber)
@@ -1321,7 +1315,7 @@ func TestMirBasic_FNodesCrashLongTimeApart(t *testing.T) {
 	t.Logf(">>> crash %d nodes", MirFaultyValidatorNumber)
 	ens.CrashMirValidators(ctx, MaxDelay, validators[:MirFaultyValidatorNumber]...)
 
-	err = kit.NoProgressForFaultyNodes(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:], nodes[:MirFaultyValidatorNumber]...)
+	err = kit.AdvanceChain(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
 	require.NoError(t, err)
 
 	t.Logf(">>> restore %d nodes", MirFaultyValidatorNumber)
@@ -1367,7 +1361,7 @@ func TestMirBasic_FNodesHaveLongPeriodNoNetworkAccessButDoNotCrash(t *testing.T)
 	t.Logf(">>> delay")
 	kit.RandomDelay(MaxDelay)
 
-	err = kit.NoProgressForFaultyNodes(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:], nodes[:MirFaultyValidatorNumber]...)
+	err = kit.AdvanceChain(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
 	require.NoError(t, err)
 
 	t.Logf(">>> reconnecting %d nodes", MirFaultyValidatorNumber)


### PR DESCRIPTION
It was found (with @matejpavlovic ) that itests disconnected validators can produce blocks even if they are disconnected. Based on that fact, we remove corresponding checks that do not make sense anymore.