### PR TITLE
Change the strategy in syncFromPeers and waitForHeight

### DIFF
--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -34,7 +34,7 @@ var (
 	LatestCheckpointKey   = datastore.NewKey("mir/latest-check")
 	LatestCheckpointPbKey = datastore.NewKey("mir/latest-check-pb")
 
-	PeerDiscoveryInterval = 300 * time.Millisecond
+	PeerDiscoveryInterval = 600 * time.Millisecond
 	PeerDiscoveryTimeout  = 3 * time.Minute
 
 	WaitForHeightTimeout = 180 * time.Second
@@ -145,6 +145,9 @@ func NewStateManager(
 
 // syncFromPeers sync the chain from Filecoin peers.
 func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
+	log.With("validator", sm.id).Infof("syncFromPeers for TSK %s started", tsk.String())
+	defer log.With("validator", sm.id).Infof("syncFromPeers for TSK %s finished", tsk.String())
+
 	// From all the peers of my daemon try to get the latest tipset.
 	timeout := time.After(PeerDiscoveryTimeout)
 	attempt := time.NewTicker(PeerDiscoveryInterval)
@@ -156,31 +159,31 @@ func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
 		if err != nil {
 			return xerrors.Errorf("failed to get peers: %w", err)
 		}
-		if len(connPeers) > 0 {
-			break
+
+		if len(connPeers) == 0 {
+			log.With("validator", sm.id).Warn("no connected peers")
 		}
 
-		log.With("validator", sm.id).Warn("no connected peers")
+		for _, p := range connPeers {
+			ts, err := sm.api.SyncFetchTipSetFromPeer(sm.ctx, p.ID, tsk)
+			if err != nil {
+				log.With("validator", sm.id).Errorf("failed to get the latest tipset from peer %s: %v", p.ID, err)
+				continue
+			}
+			// wait for full-sync before returning from restoreState.
+			err = sm.waitForHeight(ts.Height())
+			if err != nil {
+				log.With("validator", sm.id).Warnf("failed to wait for block %d: %v", ts.Height(), err)
+				continue
+			}
+			return nil
+		}
+
 		select {
 		case <-timeout:
 			return xerrors.Errorf("syncing from peers timeout exceeded")
 		case <-attempt.C:
 		}
-	}
-
-	for _, p := range connPeers {
-		ts, err := sm.api.SyncFetchTipSetFromPeer(sm.ctx, p.ID, tsk)
-		if err != nil {
-			log.With("validator", sm.id).Errorf("failed to get the latest tipset from peer %s: %v", p.ID, err)
-			continue
-		}
-		// wait for full-sync before returning from restoreState.
-		err = sm.waitForHeight(ts.Height())
-		if err != nil {
-			log.With("validator", sm.id).Warnf("failed to wait for block %d: %v", ts.Height(), err)
-			continue
-		}
-		return nil
 	}
 
 	return xerrors.Errorf("couldn't sync from peers")
@@ -252,7 +255,6 @@ func (sm *StateManager) RestoreState(checkpoint *checkpoint.StableCheckpoint) er
 		// once synced we deliver the checkpoint to our mining process, so it can be
 		// included in the next block (as the rest of Mir validators will do before
 		// accepting the next batch), and we persist it locally.
-		log.With("validator", sm.id).Infof("Delivering checkpoint for height %d to mining process after sync", ch.Height)
 		err = sm.deliverCheckpoint(checkpoint, &ch)
 		if err != nil {
 			return xerrors.Errorf("validator %v failed to deliver checkpoint to lotus from mir after restoreState: %w", sm.id, err)
@@ -553,6 +555,9 @@ func (sm *StateManager) Checkpoint(checkpoint *checkpoint.StableCheckpoint) erro
 // deliver checkpoint receives a checkpoint, persists it locally in the local block store, and delivers
 // it to the mining process to include it in a new block.
 func (sm *StateManager) deliverCheckpoint(checkpoint *checkpoint.StableCheckpoint, snapshot *Checkpoint) error {
+	log.With("validator", sm.id).Infof("deliverCheckpoint for height %d started", snapshot.Height)
+	defer log.With("validator", sm.id).Infof("deliverCheckpoint for height %d finished", snapshot.Height)
+
 	// if we deserialized it correctly, we can persist it directly in the data store.
 	if err := sm.ds.Put(sm.ctx, LatestCheckpointKey, checkpoint.Snapshot.AppData); err != nil {
 		return xerrors.Errorf("error flushing latest checkpoint in datastore: %w", err)
@@ -783,7 +788,7 @@ func WaitForHeight(ctx context.Context, height abi.ChainEpoch, api v1api.FullNod
 		case <-ctx.Done():
 			return xerrors.Errorf("context cancelled while waiting for height %v", height)
 		case <-timeout:
-			return xerrors.Errorf("time exceeded while waiting for height %v", height)
+			return xerrors.Errorf("time exceeded while waiting for target height %v beginning with %d", height, head)
 		default:
 			base, err := api.ChainHead(ctx)
 			if err != nil {

--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -178,6 +178,8 @@ func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
 		}
 
 		select {
+		case <-sm.ctx.Done():
+			return xerrors.Errorf("syncFromPeers context cancelled")
 		case <-timeout:
 			return xerrors.Errorf("syncing from peers timeout exceeded")
 		case <-attempt.C:

--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -185,8 +185,6 @@ func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
 		case <-attempt.C:
 		}
 	}
-
-	return xerrors.Errorf("couldn't sync from peers")
 }
 
 // RestoreState is called by Mir when the validator goes out-of-sync, and it requires

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -1083,7 +1083,7 @@ func (n *Ensemble) BeginMirMiningWithDelay(ctx context.Context, g *errgroup.Grou
 }
 
 func (n *Ensemble) BeginMirMining(ctx context.Context, g *errgroup.Group, validators ...*TestValidator) {
-	n.BeginMirMiningWithConfig(ctx, g, validators, &MirConfig{MembershipType: StringMembership})
+	n.BeginMirMiningWithConfig(ctx, g, validators, DefaultMirConfig())
 }
 
 // Bootstrapped explicitly sets the ensemble as bootstrapped.

--- a/itests/mir_test.go
+++ b/itests/mir_test.go
@@ -1063,7 +1063,7 @@ func TestMirBasic_WithFOmissionNodes(t *testing.T) {
 	ens.DisconnectNodes(nodes[:MirFaultyValidatorNumber], nodes[MirFaultyValidatorNumber:])
 	ens.DisconnectMirValidators(ctx, validators[:MirFaultyValidatorNumber])
 
-	err = kit.AdvanceChain(ctx, TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
+	err = kit.AdvanceChain(ctx, 5*TestedBlockNumber, nodes[MirFaultyValidatorNumber:]...)
 	require.NoError(t, err)
 
 	t.Logf(">>> reconnecting %d nodes", MirFaultyValidatorNumber)

--- a/itests/mir_test.go
+++ b/itests/mir_test.go
@@ -425,7 +425,7 @@ func TestMirReconfiguration_AddOneValidatorToMembershipWithDelay(t *testing.T) {
 		MembershipFileName: membershipFiles[MirTotalValidatorNumber],
 	})
 
-	err := kit.AdvanceChain(ctx, 4*TestedBlockNumber, nodes[:MirTotalValidatorNumber]...)
+	err := kit.AdvanceChain(ctx, 2*TestedBlockNumber, nodes[:MirTotalValidatorNumber]...)
 	require.NoError(t, err)
 	err = kit.CheckNodesInSync(ctx, 0, nodes[0], nodes[1:MirTotalValidatorNumber]...)
 	require.NoError(t, err)
@@ -441,7 +441,7 @@ func TestMirReconfiguration_AddOneValidatorToMembershipWithDelay(t *testing.T) {
 		require.Equal(t, MirTotalValidatorNumber+1, membership.Size())
 	}
 
-	err = kit.AdvanceChain(ctx, 4*TestedBlockNumber, nodes...)
+	err = kit.AdvanceChain(ctx, 2*TestedBlockNumber, nodes...)
 	require.NoError(t, err)
 	err = kit.CheckNodesInSync(ctx, 0, nodes[0], nodes[1:MirTotalValidatorNumber]...)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR:

- adds more debug information
- refactors waitForSync
- refactors syncFromPeers

The idea of refactoring is that we do not return on timeout anymore.