### PR TITLE
Add timeout for waitfor block

### DIFF
--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -35,7 +35,7 @@ var (
 	LatestCheckpointKey   = datastore.NewKey("mir/latest-check")
 	LatestCheckpointPbKey = datastore.NewKey("mir/latest-check-pb")
 
-	PeerDiscoveryInterval = 600 * time.Millisecond
+	PeerDiscoveryInterval = 800 * time.Millisecond
 	PeerDiscoveryTimeout  = 3 * time.Minute
 )
 
@@ -143,8 +143,8 @@ func NewStateManager(
 
 // syncFromPeers sync the chain from Filecoin peers.
 func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
-	log.With("validator", sm.id).Infof("syncFromPeers for TSK %s started", tsk.String())
-	defer log.With("validator", sm.id).Infof("syncFromPeers for TSK %s finished", tsk.String())
+	log.With("validator", sm.id).Infof("syncFromPeers for TSK %s started", tsk)
+	defer log.With("validator", sm.id).Infof("syncFromPeers for TSK %s finished", tsk)
 
 	// From all the peers of my daemon try to get the latest tipset.
 	timeout := time.After(PeerDiscoveryTimeout)
@@ -155,11 +155,11 @@ func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
 	for {
 		connPeers, err = sm.api.NetPeers(sm.ctx)
 		if err != nil {
-			return xerrors.Errorf("failed to get peers: %w", err)
+			return xerrors.Errorf("failed to get peers syncing to TSK %s: %w", tsk, err)
 		}
 
 		if len(connPeers) == 0 {
-			log.With("validator", sm.id).Warn("no connected peers")
+			log.With("validator", sm.id).Warnf("syncFromPeers for TSK %s: no connected peers", tsk)
 		}
 
 		for _, p := range connPeers {
@@ -168,14 +168,20 @@ func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
 				log.With("validator", sm.id).Errorf("failed to get the latest tipset from peer %s: %v", p.ID, err)
 				continue
 			}
-			// wait for full-sync before returning from restoreState.
-			err = sm.waitForHeight(ts.Height())
+
+			// Wait for full-sync before returning from restoreState.
+			// Here we use the timeout-based waitForWeight to be able to switch to another available peer if needed.
+			// If we used timeout free function then we could choose a malicious node that has sent us an incorrect tipset.
+			err = sm.waitForHeightWithTimeout(ts.Height())
 			if err != nil {
-				log.With("validator", sm.id).Warnf("failed to wait for block %d: %v", ts.Height(), err)
+				log.With("validator", sm.id).Warnf("waitForHeightWithTimeout at %d error: %v", ts.Height(), err)
 				continue
 			}
+			log.With("validator", sm.id).Infof("syncFromPeers for TSK %s completed via %v", tsk, p.ID)
 			return nil
 		}
+		// Clear the list that will be updated on the next FOR step.
+		connPeers = nil
 
 		select {
 		case <-sm.ctx.Done():
@@ -232,10 +238,15 @@ func (sm *StateManager) RestoreState(checkpoint *checkpoint.StableCheckpoint) er
 		// get checkpoint from snapshot.
 		err := ch.FromBytes(snapshot)
 		if err != nil {
-			return xerrors.Errorf("validator %v error getting checkpoint from snapshot bytes: %w", sm.id, err)
+			return xerrors.Errorf("%v failed to unmarshal checkpoint: %w", sm.id, err)
 		}
 
-		log.With("validator", sm.id).Infof("Restoring state from checkpoint at height: %d", ch.Height)
+		chCID, err := ch.Cid()
+		if err != nil {
+			return xerrors.Errorf("%v failed to get checkpoint CID: %w", sm.id, err)
+		}
+
+		log.With("validator", sm.id).Infof("Restoring state from checkpoint (%d, %v)", ch.Height, chCID)
 
 		// Restore the height, and configuration number and configuration votes.
 		sm.height = ch.Height - 1
@@ -243,11 +254,11 @@ func (sm *StateManager) RestoreState(checkpoint *checkpoint.StableCheckpoint) er
 
 		// purge any state previous to the checkpoint
 		if err = sm.api.SyncPurgeForRecovery(sm.ctx, ch.Height); err != nil {
-			return xerrors.Errorf("validator %v couldn't purge state to recover from checkpoint: %w", sm.id, err)
+			return xerrors.Errorf("%v couldn't purge state to recover from checkpoint: %w", sm.id, err)
 		}
 
 		if err = sm.syncFromPeers(types.NewTipSetKey(ch.BlockCids[0])); err != nil {
-			return xerrors.Errorf("validator %v couldn't sync from peers to recover from checkpoint at %d: %w", sm.id, ch.Height, err)
+			return xerrors.Errorf("%v couldn't sync from peers for checkpoint (%d, %v): %w", sm.id, ch.Height, chCID, err)
 		}
 
 		// once synced we deliver the checkpoint to our mining process, so it can be
@@ -255,7 +266,7 @@ func (sm *StateManager) RestoreState(checkpoint *checkpoint.StableCheckpoint) er
 		// accepting the next batch), and we persist it locally.
 		err = sm.deliverCheckpoint(checkpoint, &ch)
 		if err != nil {
-			return xerrors.Errorf("validator %v failed to deliver checkpoint to lotus from mir after restoreState: %w", sm.id, err)
+			return xerrors.Errorf("%v failed to deliver checkpoint (%d, %v) to lotus: %w", sm.id, ch.Height, chCID, err)
 		}
 	} else {
 		log.With("validator", sm.id).Infof("Snapshot len is zero")
@@ -685,9 +696,22 @@ func (sm *StateManager) releaseNextCheckpointChan() {
 	}
 }
 
+func (sm *StateManager) waitForHeightWithTimeout(height abi.ChainEpoch) error {
+	log.With("validator", sm.id).Infof("waitForHeight %v started", height)
+	defer log.With("validator", sm.id).Infof("waitForHeight %v finished", height)
+
+	ctx, cancel := context.WithDeadline(sm.ctx, time.Now().Add(5*time.Second))
+	defer cancel()
+
+	if err := WaitForHeight(ctx, height, sm.api); err != nil {
+		return xerrors.Errorf("failed to wait for a block: %w", err)
+	}
+	return nil
+}
+
 func (sm *StateManager) waitForHeight(height abi.ChainEpoch) error {
-	log.With("validator", sm.id).Debugf("waitForGeight %v started", height)
-	defer log.With("validator", sm.id).Debugf("waitForHeight %v finished", height)
+	log.With("validator", sm.id).Infof("waitForHeight %v started", height)
+	defer log.With("validator", sm.id).Infof("waitForHeight %v finished", height)
 
 	if err := WaitForHeight(sm.ctx, height, sm.api); err != nil {
 		return xerrors.Errorf("failed to wait for a block: %w", err)

--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -37,6 +37,7 @@ var (
 
 	PeerDiscoveryInterval = 800 * time.Millisecond
 	PeerDiscoveryTimeout  = 3 * time.Minute
+	WaitForHeightTimeout  = 30 * time.Second
 )
 
 type Message []byte
@@ -697,10 +698,10 @@ func (sm *StateManager) releaseNextCheckpointChan() {
 }
 
 func (sm *StateManager) waitForHeightWithTimeout(height abi.ChainEpoch) error {
-	log.With("validator", sm.id).Infof("waitForHeight %v started", height)
-	defer log.With("validator", sm.id).Infof("waitForHeight %v finished", height)
+	log.With("validator", sm.id).Debugf("waitForHeight %v started", height)
+	defer log.With("validator", sm.id).Debugf("waitForHeight %v finished", height)
 
-	ctx, cancel := context.WithDeadline(sm.ctx, time.Now().Add(5*time.Second))
+	ctx, cancel := context.WithTimeout(sm.ctx, WaitForHeightTimeout)
 	defer cancel()
 
 	if err := WaitForHeight(ctx, height, sm.api); err != nil {

--- a/chain/consensus/mir/state_manager.go
+++ b/chain/consensus/mir/state_manager.go
@@ -160,7 +160,6 @@ func (sm *StateManager) syncFromPeers(tsk types.TipSetKey) (err error) {
 		if err != nil {
 			return xerrors.Errorf("failed to get peers syncing to TSK %s: %w", tsk, err)
 		}
-		g
 		if len(connPeers) == 0 {
 			log.With("validator", sm.id).Warnf("syncFromPeers for TSK %s: no connected peers", tsk)
 		}

--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.18.0
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1
 	github.com/ipni/index-provider v0.10.0
+	github.com/jpillora/backoff v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/koalacxr/quantile v0.0.1
 	github.com/libp2p/go-buffer-pool v0.1.0
@@ -261,7 +262,6 @@ require (
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
 	github.com/klauspost/compress v1.15.10 // indirect
 	github.com/klauspost/cpuid/v2 v2.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,6 @@ require (
 	github.com/ipld/go-ipld-prime v0.18.0
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1
 	github.com/ipni/index-provider v0.10.0
-	github.com/jpillora/backoff v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/koalacxr/quantile v0.0.1
 	github.com/libp2p/go-buffer-pool v0.1.0
@@ -262,6 +261,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
 	github.com/klauspost/compress v1.15.10 // indirect
 	github.com/klauspost/cpuid/v2 v2.1.1 // indirect


### PR DESCRIPTION
This PR:

-  Adds more information for debugging
- Uses timeout-based `waitForHeight` function

It addresses this test failure - https://app.circleci.com/pipelines/github/consensus-shipyard/lotus/353/workflows/f9712132-444c-49e3-8255-8d04991215e0

In the logs, we can see that one of the joined validators runs `syncFromPeers` function but never returns from it. 
There may be other reasons for the bug, and this fix probably does not fix the root cause.