### PR TITLE
Add blocks delay parameter

### DIFF
--- a/chain/consensus/mir/manager.go
+++ b/chain/consensus/mir/manager.go
@@ -157,11 +157,12 @@ func NewManager(ctx context.Context,
 
 	params := trantor.DefaultParams(initialMembership)
 	params.Iss.SegmentLength = cfg.Consensus.SegmentLength // Segment length determining the checkpoint period.
-	params.Mempool.MaxTransactionsInBatch = 1024
+	params.Iss.MaxProposeDelay = cfg.Consensus.MaxProposeDelay * time.Second
+	params.Iss.ConfigOffset = cfg.Consensus.ConfigOffset
 	params.Iss.AdjustSpeed(1 * time.Second)
-	params.Iss.ConfigOffset = ConfigOffset
 	params.Iss.PBFTViewChangeSNTimeout = 6 * time.Second
 	params.Iss.PBFTViewChangeSegmentTimeout = 6 * time.Second
+	params.Mempool.MaxTransactionsInBatch = 1024
 	params.Mempool.TxFetcher = pool.NewFetcher(m.readyForTxsChan).Fetch
 
 	initCh := cfg.InitialCheckpoint

--- a/chain/consensus/mir/membership/membership.go
+++ b/chain/consensus/mir/membership/membership.go
@@ -11,6 +11,15 @@ import (
 	"github.com/filecoin-project/lotus/chain/ipcagent/rpc"
 )
 
+type MembershipType int32
+
+const (
+	FakeType    MembershipType = 0
+	StringType  MembershipType = 1
+	FileType    MembershipType = 2
+	OnChainType MembershipType = 3
+)
+
 type Reader interface {
 	GetValidatorSet() (*validator.Set, error)
 }

--- a/chain/consensus/mir/types.go
+++ b/chain/consensus/mir/types.go
@@ -26,9 +26,6 @@ import (
 )
 
 const (
-	// ConfigOffset is the number of epochs by which to delay configuration changes.
-	// If a configuration is agreed upon in epoch e, it will take effect in epoch e + 1 + configOffset.
-	ConfigOffset         = 2
 	TransportRequest     = 1
 	ConfigurationRequest = 0
 )

--- a/cmd/eudico/mirvalidator/run.go
+++ b/cmd/eudico/mirvalidator/run.go
@@ -81,7 +81,14 @@ var runCmd = &cli.Command{
 		&cli.IntFlag{
 			Name:  "segment-length",
 			Usage: "The length of an ISS segment. Must not be negative",
-			Value: 1,
+		},
+		&cli.DurationFlag{
+			Name:  "blocks-delay",
+			Usage: "The maximum delay in seconds between two blocks",
+		},
+		&cli.IntFlag{
+			Name:  "config-offset",
+			Usage: "Number of epochs by which to delay configuration changes",
 		},
 		&cli.StringFlag{
 			Name:  "ipcagent-url",
@@ -146,9 +153,6 @@ var runCmd = &cli.Command{
 			return err
 		}
 
-		// Segment length period.
-		segmentLength := cctx.Int("segment-length")
-
 		h, err := getLibP2PHost(cctx.String("repo"))
 		if err != nil {
 			return err
@@ -187,12 +191,15 @@ var runCmd = &cli.Command{
 			dbPath,
 			initCh,
 			cctx.String("checkpoints-repo"),
-			segmentLength,
+			cctx.Int("segment-length"),
+			cctx.Int("config-offset"),
+			cctx.Duration("blocks-interval"),
 			cctx.String("ipcagent-url"),
+			cctx.String("membership"),
 		)
 
 		var mb membership.Reader
-		switch cctx.String("membership") {
+		switch cfg.MembershipTypeValue {
 		case "file":
 			mf := filepath.Join(cctx.String("repo"), cctx.String("membership-file"))
 			mb = membership.NewFileMembership(mf)

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -42,6 +42,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/power"
+	"github.com/filecoin-project/lotus/chain/consensus/mir/membership"
 	"github.com/filecoin-project/lotus/chain/gen"
 	genesis2 "github.com/filecoin-project/lotus/chain/gen/genesis"
 	"github.com/filecoin-project/lotus/chain/messagepool"
@@ -1101,7 +1102,7 @@ func (n *Ensemble) BeginMirMiningWithDelayForFaultyNodes(
 	validators []*TestValidator,
 	faultyValidators ...*TestValidator,
 ) {
-	n.BeginMirMiningWithConfig(ctx, g, validators, &MirConfig{Delay: delay, MembershipType: StringMembership}, faultyValidators...)
+	n.BeginMirMiningWithConfig(ctx, g, validators, &MirConfig{Delay: delay, MembershipType: membership.StringType}, faultyValidators...)
 }
 
 func (n *Ensemble) BeginMirMiningWithConfig(

--- a/itests/kit/mir_validator.go
+++ b/itests/kit/mir_validator.go
@@ -19,18 +19,11 @@ import (
 	mirtypes "github.com/filecoin-project/mir/pkg/types"
 )
 
-const (
-	FakeMembership    = 0
-	StringMembership  = 1
-	FileMembership    = 2
-	OnChainMembership = 3
-)
-
 type MirConfig struct {
 	Delay              int
 	MembershipFileName string
 	MembershipString   string
-	MembershipType     int
+	MembershipType     membership.MembershipType
 	MembershipFilename string
 	Databases          map[string]*TestDB
 	MockedTransport    bool
@@ -38,7 +31,7 @@ type MirConfig struct {
 
 func DefaultMirConfig() *MirConfig {
 	return &MirConfig{
-		MembershipType: StringMembership,
+		MembershipType: membership.StringType,
 	}
 }
 
@@ -72,20 +65,20 @@ func NewMirValidator(t *testing.T, miner *TestValidator, db *TestDB, cfg *MirCon
 	}
 
 	switch cfg.MembershipType {
-	case FakeMembership:
+	case membership.FakeType:
 		v.membership = fakeMembership{}
-	case StringMembership:
+	case membership.StringType:
 		if cfg.MembershipString == "" {
 			return nil, fmt.Errorf("empty membership string")
 		}
 		v.membershipString = cfg.MembershipString
 		v.membership = membership.StringMembership(cfg.MembershipString)
-	case FileMembership:
+	case membership.FileType:
 		if cfg.MembershipFileName == "" {
 			return nil, fmt.Errorf("membership file is not specified")
 		}
 		v.membership = membership.FileMembership{FileName: cfg.MembershipFileName}
-	case OnChainMembership:
+	case membership.OnChainType:
 		cl := NewStubJSONRPCClient()
 		cl.nextSet = cfg.MembershipString
 		v.membership = membership.NewOnChainMembershipClient(cl, ITestSubnet)

--- a/itests/mir_test.go
+++ b/itests/mir_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/chain/consensus/mir"
+	mb "github.com/filecoin-project/lotus/chain/consensus/mir/membership"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/itests/kit"
 )
@@ -81,7 +82,7 @@ func TestMirReconfiguration_AddAndRemoveOneValidator(t *testing.T) {
 
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[:MirTotalValidatorNumber],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -99,7 +100,7 @@ func TestMirReconfiguration_AddAndRemoveOneValidator(t *testing.T) {
 	// Start new validators.
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[MirTotalValidatorNumber:],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -161,7 +162,7 @@ func TestMirReconfigurationOnChain_RunSubnetWithStubJSONRPC(t *testing.T) {
 
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[:MirTotalValidatorNumber],
 		&kit.MirConfig{
-			MembershipType: kit.OnChainMembership,
+			MembershipType: mb.OnChainType,
 		})
 
 	err := kit.AdvanceChain(ctx, 2*TestedBlockNumber, nodes[:MirTotalValidatorNumber]...)
@@ -200,7 +201,7 @@ func TestMirReconfiguration_AddOneValidatorAtHeight(t *testing.T) {
 
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[:MirTotalValidatorNumber],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -218,7 +219,7 @@ func TestMirReconfiguration_AddOneValidatorAtHeight(t *testing.T) {
 	// Start new validators.
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[MirTotalValidatorNumber:],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -293,7 +294,7 @@ func TestMirReconfiguration_AddOneValidatorWithConfigurationRecovery(t *testing.
 
 	ens.InterconnectFullNodes()
 	ens.BeginMirMiningWithConfig(ctx, g, validators[:MirTotalValidatorNumber], &kit.MirConfig{
-		MembershipType:     kit.FileMembership,
+		MembershipType:     mb.FileType,
 		MembershipFileName: membershipFileName,
 		Databases:          dbs,
 	})
@@ -341,7 +342,7 @@ func TestMirReconfiguration_AddOneValidatorWithConfigurationRecovery(t *testing.
 	ens.InterconnectFullNodes()
 
 	ens.BeginMirMiningWithConfig(ctx, g, validators[MirTotalValidatorNumber:], &kit.MirConfig{
-		MembershipType:     kit.FileMembership,
+		MembershipType:     mb.FileType,
 		MembershipFileName: membershipFileName,
 		Databases:          dbs,
 	})
@@ -415,13 +416,13 @@ func TestMirReconfiguration_AddOneValidatorToMembershipWithDelay(t *testing.T) {
 	ens.InterconnectFullNodes()
 	for i := 0; i < MirTotalValidatorNumber; i++ {
 		ens.BeginMirMiningWithConfig(ctx, g, []*kit.TestValidator{validators[i]}, &kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFiles[i],
 		})
 	}
 
 	ens.BeginMirMiningWithConfig(ctx, g, validators[MirTotalValidatorNumber:], &kit.MirConfig{
-		MembershipType:     kit.FileMembership,
+		MembershipType:     mb.FileType,
 		MembershipFileName: membershipFiles[MirTotalValidatorNumber],
 	})
 
@@ -479,7 +480,7 @@ func TestMirReconfiguration_AddValidatorsOnce(t *testing.T) {
 
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[:initialValidatorNumber],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -496,7 +497,7 @@ func TestMirReconfiguration_AddValidatorsOnce(t *testing.T) {
 	// Start new validators.
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[initialValidatorNumber:],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -537,7 +538,7 @@ func TestMirReconfiguration_AddValidatorsOneByOne(t *testing.T) {
 
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[:MirTotalValidatorNumber],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -559,7 +560,7 @@ func TestMirReconfiguration_AddValidatorsOneByOne(t *testing.T) {
 		// Start new validators.
 		ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, []*kit.TestValidator{validators[MirTotalValidatorNumber+i-1]},
 			&kit.MirConfig{
-				MembershipType:     kit.FileMembership,
+				MembershipType:     mb.FileType,
 				MembershipFileName: membershipFileName,
 			})
 
@@ -600,7 +601,7 @@ func TestMirReconfiguration_NewNodeFailsToJoin(t *testing.T) {
 	ens.SaveValidatorSetToFile(0, membershipFileName, validators[:MirTotalValidatorNumber]...)
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators[:MirTotalValidatorNumber],
 		&kit.MirConfig{
-			MembershipType:     kit.FileMembership,
+			MembershipType:     mb.FileType,
 			MembershipFileName: membershipFileName,
 		})
 
@@ -1052,7 +1053,7 @@ func TestMirBasic_WithFOmissionNodes(t *testing.T) {
 
 	nodes, validators, ens := kit.EnsembleWithMirValidators(t, MirTotalValidatorNumber)
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators, &kit.MirConfig{
-		MembershipType:  kit.StringMembership,
+		MembershipType:  mb.StringType,
 		MockedTransport: true,
 	})
 
@@ -1247,7 +1248,7 @@ func TestMirSmoke_StopWithError(t *testing.T) {
 
 	nodes, validators, ens := kit.EnsembleWithMirValidators(t, MirTotalValidatorNumber)
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators, &kit.MirConfig{
-		MembershipType: kit.FakeMembership,
+		MembershipType: mb.FakeType,
 	})
 
 	err := kit.AdvanceChain(ctx, 10, nodes...)
@@ -1346,7 +1347,7 @@ func TestMirBasic_FNodesHaveLongPeriodNoNetworkAccessButDoNotCrash(t *testing.T)
 	nodes, validators, ens := kit.EnsembleWithMirValidators(t, MirTotalValidatorNumber)
 	ens.InterconnectFullNodes().BeginMirMiningWithConfig(ctx, g, validators,
 		&kit.MirConfig{
-			MembershipType:  kit.StringMembership,
+			MembershipType:  mb.StringType,
 			MockedTransport: true,
 		},
 	)


### PR DESCRIPTION
This PR:

- adds `blocks-delay` parameter
- removes default values for main configuration parameters from the CMD package