### PR TITLE
Fix validator-addr retrieval & container naming

### DIFF
--- a/scripts/ipc/run-subnet-docker.sh
+++ b/scripts/ipc/run-subnet-docker.sh
@@ -13,7 +13,7 @@ PORT=$1
 VAL_PORT=$2
 SUBNETID=${3%/}
 VAL_KEY_ABSOLUTE_PATH=$4
-CONTAINER_NAME=ipc${SUBNETID//\//_}_$PORT
+CONTAINER_NAME=`echo ipc${SUBNETID}_${PORT} | sed 's/\//_/g'`
 
 echo "[*] Running docker container for root in port $PORT"
 img=`docker run -dit --add-host host.docker.internal:host-gateway -p $PORT:1234 -p $VAL_PORT:1347 -v $VAL_KEY_ABSOLUTE_PATH:/wallet.key:ro --name $CONTAINER_NAME --entrypoint "/scripts/ipc/entrypoints/eudico-subnet.sh" eudico $SUBNETID`
@@ -26,8 +26,7 @@ token=`docker exec -it $img  eudico auth create-token --perm admin`
 echo ">>> Token to $SUBNETID daemon: $token"
 wallet=`docker exec -it $img  eudico wallet default`
 echo ">>> Default wallet: $wallet"
-val=`docker exec -it $img  eudico mir validator config validator-addr | sed q1`
 echo ">>> Subnet subnet validator info:"
-echo $val
+docker exec -it $img  eudico mir validator config validator-addr
 echo ">>> API listening in host port $PORT"
 echo ">>> Validator listening in host port $VAL_PORT"

--- a/scripts/ipc/run-subnet-docker.sh
+++ b/scripts/ipc/run-subnet-docker.sh
@@ -26,7 +26,7 @@ token=`docker exec -it $img  eudico auth create-token --perm admin`
 echo ">>> Token to $SUBNETID daemon: $token"
 wallet=`docker exec -it $img  eudico wallet default`
 echo ">>> Default wallet: $wallet"
-val=`docker exec -it $img  eudico mir validator config validator-addr`
+val=`docker exec -it $img  eudico mir validator config validator-addr | sed q1`
 echo ">>> Subnet subnet validator info:"
 echo $val
 echo ">>> API listening in host port $PORT"


### PR DESCRIPTION
```
ubuntu@ip-172-26-28-130:~/ipc/ipc-agent$ bin/ipc-infra/run-subnet-docker.sh 1240 1350 /root/t01003 ~/.ipc_agent/wallet.key
>>> Subnet /root/t01003 daemon running in container: be5a7ca5d7da0fbd41fdb206abdf6159338ef76c3e922e3bce4f4649ef2cd98c (friendly name: ipc_root_t01003_1240)
>>> Token to /root/t01003 daemon: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.K2Y5-FbhjBHfyRQ6lMOrKmrnsycvI6uRdS9muKYEPPU
>>> Default wallet: t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq
>>> Subnet subnet validator info:
 t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq@/ip4/127.0.0.1/tcp/1347/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBiooHBio
>>> API listening in host port 1240
>>> Validator listening in host port 1350

ubuntu@ip-172-26-28-130:~/ipc/ipc-agent$ docker exec -it ipc_root_t01003_1240 eudico mir validator config validator-addr
t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq@/ip4/172.17.0.4/udp/1348/quic/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBio
t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq@/ip4/127.0.0.1/udp/1348/quic/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBio
t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq@/ip4/172.17.0.4/tcp/1347/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBio
t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq@/ip4/127.0.0.1/tcp/1347/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBio

ubuntu@ip-172-26-28-130:~/ipc/ipc-agent$ ./bin/ipc_agent join-subnet --subnet=/root/t01003 --collateral=2 --validator-net-addr="/ip4/127.0.0.1/tcp/1347/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBiooHBio"
[2023-03-29T20:31:43Z INFO  ipc_agent::cli::commands::manager::join] joined subnet: /root/t01003

ubuntu@ip-172-26-28-130:~/ipc/ipc-agent$ ./bin/ipc-infra/mine-subnet.sh ipc_root_t01003_1240
[*] Starting to mine on validator
2023-03-29T20:32:17.959Z        INFO    mir-validator-cli       mirvalidator/run.go:143 Checking full node sync status
2023/03/29 20:32:17 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB). See https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size for details.
2023-03-29T20:32:17.964Z        INFO    mir-validator-cli       mirvalidator/run.go:162 Mir libp2p host listening in the following addresses:
2023-03-29T20:32:17.964Z        INFO    mir-validator-cli       mirvalidator/run.go:164 /ip4/172.17.0.4/udp/1348/quic
2023-03-29T20:32:17.964Z        INFO    mir-validator-cli       mirvalidator/run.go:164 /ip4/127.0.0.1/udp/1348/quic
2023-03-29T20:32:17.964Z        INFO    mir-validator-cli       mirvalidator/run.go:164 /ip4/172.17.0.4/tcp/1347
2023-03-29T20:32:17.964Z        INFO    mir-validator-cli       mirvalidator/run.go:164 /ip4/127.0.0.1/tcp/1347
2023-03-29T20:32:17.974Z        INFO    mir-validator-cli       mirvalidator/run.go:228 Starting mining with validator  {"validator": "t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq"}
ERROR: t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq failed to create manager: validator t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq failed to build node membership: failed to parse multiaddr "/ip4/127.0.0.1/tcp/1347/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBiooHBio": invalid value "12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBiooHBio" for protocol p2p: failed to parse p2p addr: 12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBiooHBio multihash length inconsistent: expected 5; got 7

ubuntu@ip-172-26-28-130:~/ipc/ipc-agent$ ./bin/ipc_agent set-validator-net-addr --subnet=/root/t01003 --validator-net-addr="/ip4/172.17.0.4/udp/1348/quic/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBio"
[2023-03-29T20:34:14Z INFO  ipc_agent::cli::commands::manager::net_addr] set the validator net addr to: /ip4/172.17.0.4/udp/1348/quic/p2p/12D3KooWJqyxkd5URfnB8jpoA1JK5E5Ld7CtjYTfEoTyWRWmHBio in subnet: /root/t01003

ubuntu@ip-172-26-28-130:~/ipc/ipc-agent$ ./bin/ipc-infra/mine-subnet.sh ipc_root_t01003_1240 
[everything works fine...]
```

Symptom: Taking the validator address printed by run-subnet-docker.sh and using it to join the network causes the miner process to fail due to inconsistent multihash length. 

Cause: The validator-addr command returns 4 lines and each overwrites the starting bytes of the output buffer; however, if the previous lines were longer, the trailing bytes remain. So we end up with a longer invalid address with repeated characters at the end.

~Tiny fix: just take `sed q1` if we're fine with printing a single address (which I prefer for the sake of the guide, as it's less confusing, but might be suboptimal for production?). Alternatively, let's just pass through the command output without the variable assignment, i.e.~

Tiny fix: let's just print the entire output

Moreover, this replaces bash subtitution with sed to improve system compatibility.