### PR TITLE
Installl eudico, less chatty log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,10 +170,10 @@ an existing lotus binary in your PATH. This may cause problems if you don't run 
 
 .PHONY: build
 
-install: install-daemon install-miner install-worker
+install: install-daemon
 
 install-daemon:
-	install -C ./lotus /usr/local/bin/lotus
+	install -C ./eudico /usr/local/bin/eudico
 
 install-miner:
 	install -C ./lotus-miner /usr/local/bin/lotus-miner

--- a/chain/rand/rand.go
+++ b/chain/rand/rand.go
@@ -115,9 +115,9 @@ func NewStateRand(cs *store.ChainStore, blks []cid.Cid, b beacon.Schedule, netwo
 	// we don't use winningPoSt and we use fake windowPoSt when running
 	// mir consensus (at least for now)
 	if global.IsConsensusAlgorithm(global.MirConsensus) {
-		log.Warn("=================================================================================")
-		log.Warn("DANGER ZONE! YOU ARE USING FAKE RANDOMNESS FOR YOUR VM AND PROOFS. USE WITH CARE!")
-		log.Warn("=================================================================================")
+		log.Debug("=================================================================================")
+		log.Debug("DANGER ZONE! YOU ARE USING FAKE RANDOMNESS FOR YOUR VM AND PROOFS. USE WITH CARE!")
+		log.Debug("=================================================================================")
 		return &fakeRand{}
 	}
 

--- a/eudico-core/genesis/genesis.json
+++ b/eudico-core/genesis/genesis.json
@@ -9,6 +9,13 @@
         "Owner": "t3tat272hqg2h6fuokkun4xx742flp72iwvnsao5z4ba7c5qwhjlumyuklcnudg74phfvxaqd52ncb5vhutu2a"
       }
   },
+      {
+      "Type": "account",
+      "Balance": "50000000000000000000000000",
+      "Meta": {
+          "Owner": "t1jlm55oqkdalh2l3akqfsaqmpjxgjd36pob34dqy"
+      }
+  },
     {
     "Type": "account",
     "Balance": "5000000000000000000000",


### PR DESCRIPTION
This PR fixes `make install` so it installs the `eudico` binary instead of Lotus, and it removes the WARN log for the fake randomness that was printed every time that a new block is executed. 