### PR TITLE
Print formatted validator address

### DIFF
--- a/scripts/ipc/run-subnet-docker.sh
+++ b/scripts/ipc/run-subnet-docker.sh
@@ -27,6 +27,6 @@ echo ">>> Token to $SUBNETID daemon: $token"
 wallet=`docker exec -it $img  eudico wallet default`
 echo ">>> Default wallet: $wallet"
 echo ">>> Subnet subnet validator info:"
-docker exec -it $img  eudico mir validator config validator-addr
+docker exec -it $img eudico mir validator config validator-addr | grep '127.0.0.1/tcp' | sed 's/^.*\/127.0.0.1/\/dns\/host.docker.internal/' | sed -E "s/\/[0-9]+\//\/$VAL_PORT\//"
 echo ">>> API listening in host port $PORT"
 echo ">>> Validator listening in host port $VAL_PORT"


### PR DESCRIPTION
This formats the validator address output by eudico into the right format for later consumption by the ipc-agent. It's specific to the docker deployment, but so is the script. Nevertheless, we may or may not want to make the change. Discussion in https://github.com/consensus-shipyard/ipc-agent/pull/146#discussion_r1155139074

