### PR TITLE
fix: bottom-up applied nonce initial state

### DIFF
--- a/chain/gen/genesis/f08_ipc_gateway.go
+++ b/chain/gen/genesis/f08_ipc_gateway.go
@@ -26,9 +26,8 @@ const (
 	DefaultCheckpointPeriod = 10
 	DefaultIPCGatewayAddrID = 64
 
-	bitWidth  = 5
-	minStake  = 1000000000000000000
-	MaxUint64 = ^uint64(0)
+	bitWidth = 5
+	minStake = 1000000000000000000
 )
 
 var (
@@ -57,7 +56,7 @@ func constructState(store adt.Store, network ipctypes.SubnetID, buPeriod, tdPeri
 		BottomUpCheckpoints:  emptyMapCid,
 		Postbox:              emptyMapCid,
 		BottomupNonce:        0,
-		AppliedBottomupNonce: MaxUint64,
+		AppliedBottomupNonce: 0,
 		AppliedTopdownNonce:  0,
 		TopDownCheckVoting:   voting,
 	}, nil


### PR DESCRIPTION
This PR fixes a bug for which the initial state for the `AppliedBottomUpNonce` was being set to `MaxInt` instead of `0`. After the actor refactor, this is expected to be `0` for the subsequent application of messages. 

This also introduces a new bug that will be fixed in a follow-up PR, where we should have a different account of applied nonces for each child subnet. 

