### PR TITLE
Mir 0.3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/filecoin-project/go-statemachine v1.0.3
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/go-storedcounter v0.1.0
-	github.com/filecoin-project/mir v0.3.4
+	github.com/filecoin-project/mir v0.3.5
 	github.com/filecoin-project/pubsub v1.0.0
 	github.com/filecoin-project/specs-actors v0.9.15
 	github.com/filecoin-project/specs-actors/v2 v2.3.6

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNd
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
 github.com/filecoin-project/go-storedcounter v0.1.0 h1:Mui6wSUBC+cQGHbDUBcO7rfh5zQkWJM/CpAZa/uOuus=
 github.com/filecoin-project/go-storedcounter v0.1.0/go.mod h1:4ceukaXi4vFURIoxYMfKzaRF5Xv/Pinh2oTnoxpv+z8=
-github.com/filecoin-project/mir v0.3.4 h1:RES4mGdt/Rhp7wg+Nr6eV9rcUPDMN2oyKG2w4KlAgTQ=
-github.com/filecoin-project/mir v0.3.4/go.mod h1:2YHupCVJypLmxkVC2BH23owbWaXtBuk15iJrQIQnygw=
+github.com/filecoin-project/mir v0.3.5 h1:/4bdw/0aW2eC1pX/65By2bRUMx/OAGkc5/olSmLujdo=
+github.com/filecoin-project/mir v0.3.5/go.mod h1:2YHupCVJypLmxkVC2BH23owbWaXtBuk15iJrQIQnygw=
 github.com/filecoin-project/pubsub v1.0.0 h1:ZTmT27U07e54qV1mMiQo4HDr0buo8I1LDHBYLXlsNXM=
 github.com/filecoin-project/pubsub v1.0.0/go.mod h1:GkpB33CcUtUNrLPhJgfdy4FDx4OMNR9k+46DHx/Lqrg=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=


### PR DESCRIPTION
This PR updates the Mir to the latest version that [fixes](https://github.com/filecoin-project/mir/commit/c716023aa29e4efb7c46a753507e531d33c66090) a subtle bug.