### PR TITLE
Replace bootstrappers ip with dns

### DIFF
--- a/build/bootstrap/spacenet.pi
+++ b/build/bootstrap/spacenet.pi
@@ -1,2 +1,2 @@
-/ip4/3.66.145.60/tcp/1347/p2p/12D3KooWBgvwdJfJzi33n3RtesHdXvW16pGqaVgzD2WCijxvwEp1
-/ip4/52.29.194.50/tcp/1347/p2p/12D3KooW9u5RNjcw5zbkZcWGo2WWwjEbvr1Qz7sTs9GpxNw5xNzC
+/dns4/bootstrap-1.spacenet.ipc.space/tcp/1347/p2p/12D3KooWBgvwdJfJzi33n3RtesHdXvW16pGqaVgzD2WCijxvwEp1
+/dns4/bootstrap-2.spacenet.ipc.space/tcp/1347/p2p/12D3KooW9u5RNjcw5zbkZcWGo2WWwjEbvr1Qz7sTs9GpxNw5xNzC


### PR DESCRIPTION
Shouldn't have any immediate consequences but will be more robust against future infra changes.