### PR TITLE
enable RPC API in bootstraps

### DIFF
--- a/scripts/ipc/src/subnet-daemon.sh
+++ b/scripts/ipc/src/subnet-daemon.sh
@@ -16,6 +16,8 @@ echo '
   EnableSplitstore = true
 [API]
   ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
+[Fevm]
+  EnableEthRPC = true
 ' > $LOTUS_PATH/config.toml
 
 echo "[*] Generate genesis for subnet deterministically"


### PR DESCRIPTION
This PR enables the EthRPC by default in the subnet IPC deployment scripts. 