### PR TITLE
enable eth-rpc in 4-node-net script (#188)

### DIFF
--- a/scripts/mir/daemon.sh
+++ b/scripts/mir/daemon.sh
@@ -37,6 +37,17 @@ mkdir $LOTUS_PATH
 #    ./eudico mir daemon --eudico-make-genesis=./scripts/mir/devgen.car --genesis-template=./scripts/mir/localnet.json --bootstrap=false --api=123$INDEX
 # else
 
+echo "[*] Populating daemon config"
+echo '[Libp2p]
+ListenAddresses = ["/ip4/0.0.0.0/tcp/1347"]
+[Chainstore]
+  EnableSplitstore = true
+[Chainstore.Splitstore]
+  ColdStoreType = "discard"
+[Fevm]
+  EnableEthRPC = true
+' > $LOTUS_PATH/config.toml
+
 API_PORT=""
 if [ "$PORT" != 0 ]
 then


### PR DESCRIPTION
Propagates config changes to `spacenet` branch, so as to enable ethrpc by default on subnet docker containers.