### PR TITLE
Fixes a bug for which FEVM events weren't being stored

### DIFF
--- a/cmd/eudico/daemon.go
+++ b/cmd/eudico/daemon.go
@@ -317,7 +317,7 @@ func eudicoDaemonAction(consensusAlgorithm global.ConsensusAlgorithm) func(*cli.
 		app := fx.New(
 			fxProviders,
 			fx.Populate(&rpcStopper),
-			fxmodules.Invokes(&cfg.Common, cctx.Bool("bootstrap"), isMirValidator),
+			fxmodules.Invokes(cfg, cctx.Bool("bootstrap"), isMirValidator),
 			// Debugging of the dependency graph
 			fx.Invoke(
 				func(dotGraph fx.DotGraph) {

--- a/cmd/lotus/eudico.go
+++ b/cmd/lotus/eudico.go
@@ -230,7 +230,7 @@ func eudicoDaemonAction(cctx *cli.Context) error {
 	app := fx.New(
 		fxProviders,
 		fx.Populate(&rpcStopper),
-		fxmodules.Invokes(&cfg.Common, cctx.Bool("bootstrap"), isMirValidator),
+		fxmodules.Invokes(cfg, cctx.Bool("bootstrap"), isMirValidator),
 		// Debugging of the dependency graph
 		fx.Invoke(
 			func(dotGraph fx.DotGraph) {

--- a/eudico-core/fxmodules/invokes.go
+++ b/eudico-core/fxmodules/invokes.go
@@ -10,23 +10,24 @@ import (
 	"github.com/filecoin-project/lotus/paychmgr/settler"
 )
 
-func Invokes(cfg *config.Common, isBootstrap bool, isMirValidator bool) fx.Option {
+func Invokes(cfg *config.FullNode, isBootstrap bool, isMirValidator bool) fx.Option {
 	return fx.Module("invokes",
 		fx.Invoke(
-			modules.MemoryWatchdog,                          // 1 defaults
-			modules.CheckFdLimit(build.DefaultFDLimit),      // 2 defaults
-			lp2p.PstoreAddSelfKeys,                          // 3 libp2p
-			lp2p.StartListening(cfg.Libp2p.ListenAddresses), // 4 common config
-			modules.DoSetGenesis,                            // 6
-			modules.RunHello,                                // 7
-			modules.RunChainExchange,                        // 8
-			modules.HandleIncomingMessages,                  // 12
-			modules.HandleMigrateClientFunds,                // 13
-			modules.HandlePaychManager,                      // 14
-			modules.RelayIndexerMessages,                    // 15
-			settler.SettlePaymentChannels,                   // 24
+			modules.MemoryWatchdog,                                 // 1 defaults
+			modules.CheckFdLimit(build.DefaultFDLimit),             // 2 defaults
+			lp2p.PstoreAddSelfKeys,                                 // 3 libp2p
+			lp2p.StartListening(cfg.Common.Libp2p.ListenAddresses), // 4 common config
+			modules.DoSetGenesis,                                   // 6
+			modules.RunHello,                                       // 7
+			modules.RunChainExchange,                               // 8
+			modules.HandleIncomingMessages,                         // 12
+			modules.HandleMigrateClientFunds,                       // 13
+			modules.HandlePaychManager,                             // 14
+			modules.RelayIndexerMessages,                           // 15
+			settler.SettlePaymentChannels,                          // 24
 		),
 		fxOptional(isBootstrap, fx.Invoke(modules.RunPeerMgr)),               // 10
 		fxOptional(!isMirValidator, fx.Invoke(modules.HandleIncomingBlocks)), // 11
+		fxOptional(cfg.Fevm.EnableEthRPC, fx.Invoke(modules.EnableStoringEvents)),
 	)
 }

--- a/itests/kit/ensemble.go
+++ b/itests/kit/ensemble.go
@@ -460,7 +460,7 @@ func (n *Ensemble) Start() *Ensemble {
 
 		app := fx.New(
 			fxProviders,
-			fxmodules.Invokes(&cfg.Common, false, !full.options.learner),
+			fxmodules.Invokes(cfg, false, !full.options.learner),
 			fx.Invoke(func(fullNode impl.FullNodeAPI) {
 				full.FullNode = &fullNode
 			}),


### PR DESCRIPTION
Several users (including ourselves) where experiencing weird behaviors when interacting with FEVM contracts that returned a variable and/or emitted an event. For some reason, the clients were getting stuck while waiting for the transaction receipt. 

The reason was that we weren't storing successfully in the ChainStore the events from FEVM contracts, so the client froze waiting for some new event related to the receipt to appear in the state. This PR fixes the problem.    