### PR TITLE
Rely on heightDiff instead of timestamp for Mir checks

### DIFF
--- a/gateway/node.go
+++ b/gateway/node.go
@@ -222,7 +222,7 @@ func (gw *Node) checkTipset(ts *types.TipSet) error {
 		if err != nil {
 			return err
 		}
-		if h.Height() > ts.Height() {
+		if h.Height() < ts.Height() {
 			return fmt.Errorf("tipset height in future")
 		}
 		if (h.Height() - ts.Height()) > DefaultMirHeightDiff {


### PR DESCRIPTION
In Mir we don't use timestamps to identify blocks, which makes Lookback-related checks in the gateway to have unexpected behaviors. To avoid this, we rely on height diffs for lookback checks if we are using Mir as the consensus algorithm for the peer.